### PR TITLE
PhosphorIcon widget updated to allow generic IconData.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## [2.0.1] - 2023/11/04
+
+- Fix duotone icons alignment
+- Fix duotone icons not working on web
+
 ## [2.0.0] - 2023/04/04
 
 This release adds 201 new icons to the family:

--- a/bin/generate_package_icons.dart
+++ b/bin/generate_package_icons.dart
@@ -1,9 +1,9 @@
+import 'package:code_builder/code_builder.dart';
+import 'package:dart_style/dart_style.dart';
+
 import 'extensions.dart';
 import 'style_file_data.dart';
 import 'utils.dart';
-
-import 'package:code_builder/code_builder.dart';
-import 'package:dart_style/dart_style.dart';
 
 /// Generated the main class of the package that exposes all the style classes
 void generateMainClass(List<StyleFileData> styles) {
@@ -166,7 +166,7 @@ Field buildFieldIconByStyle(dynamic icon, {required StyleFileData style}) {
     final backgroundHexCode = '0x' + graphCodes.first.toRadixString(16);
     final foregroundHexCode = '0x' + graphCodes.last.toRadixString(16);
     codeStatement = Code(
-      "PhosphorDuotoneIconData($foregroundHexCode, PhosphorIconData($backgroundHexCode, 'duotone'),)",
+      "PhosphorDuotoneIconData($foregroundHexCode, PhosphorIconData($backgroundHexCode, 'Duotone'),)",
     );
   } else {
     final graphCode = properties['code'] as int;

--- a/bin/pubspec.lock
+++ b/bin/pubspec.lock
@@ -5,34 +5,34 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: a36ec4843dc30ea6bf652bf25e3448db6c5e8bcf4aa55f063a5d1dad216d8214
+      sha256: "36a321c3d2cbe01cbcb3540a87b8843846e0206df3e691fa7b23e19e78de6d49"
       url: "https://pub.dev"
     source: hosted
-    version: "58.0.0"
+    version: "65.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: cc4242565347e98424ce9945c819c192ec0838cb9d1f6aa4a97cc96becbc5b27
+      sha256: dfe03b90ec022450e22513b5e5ca1f01c0c01de9c3fba2f7fd233cb57a6b9a07
       url: "https://pub.dev"
     source: hosted
-    version: "5.10.0"
+    version: "6.3.0"
   archive:
     dependency: "direct main"
     description:
       name: archive
-      sha256: d6347d54a2d8028e0437e3c099f66fdb8ae02c4720c1e7534c9f24c10351f85d
+      sha256: "7e0d52067d05f2e0324268097ba723b71cb41ac8a6a2b24d1edf9c536b987b03"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.6"
+    version: "3.4.6"
   args:
     dependency: transitive
     description:
       name: args
-      sha256: "4cab82a83ffef80b262ddedf47a0a8e56ee6fbf7fe21e6e768b02792034dd440"
+      sha256: eef6c46b622e0494a36c5a12d10d77fb4e855501a91c1b9ef9339326e58f0596
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "2.4.2"
   async:
     dependency: transitive
     description:
@@ -61,26 +61,26 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: "31b7c748fd4b9adf8d25d72a4c4a59ef119f12876cf414f94f8af5131d5fa2b0"
+      sha256: "723b4021e903217dfc445ec4cf5b42e27975aece1fc4ebbc1ca6329c2d9fb54e"
       url: "https://pub.dev"
     source: hosted
-    version: "8.4.4"
+    version: "8.7.0"
   code_builder:
     dependency: "direct main"
     description:
       name: code_builder
-      sha256: "0d43dd1288fd145de1ecc9a3948ad4a6d5a82f0a14c4fdd0892260787d975cbe"
+      sha256: "1be9be30396d7e4c0db42c35ea6ccd7cc6a1e19916b5dc64d6ac216b5544d677"
       url: "https://pub.dev"
     source: hosted
-    version: "4.4.0"
+    version: "4.7.0"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.1"
+    version: "1.18.0"
   convert:
     dependency: transitive
     description:
@@ -93,26 +93,26 @@ packages:
     dependency: transitive
     description:
       name: crypto
-      sha256: aa274aa7774f8964e4f4f38cc994db7b6158dd36e9187aaceaddc994b35c6c67
+      sha256: ff625774173754681d66daaf4a448684fb04b78f902da9cb3d308c19cc5e8bab
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.3"
   dart_style:
     dependency: "direct main"
     description:
       name: dart_style
-      sha256: "6d691edde054969f0e0f26abb1b30834b5138b963793e56f69d3a9a4435e6352"
+      sha256: abd7625e16f51f554ea244d090292945ec4d4be7bfbaf2ec8cccea568919d334
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
+    version: "2.3.3"
   file:
     dependency: transitive
     description:
       name: file
-      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
+      sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.4"
+    version: "7.0.0"
   fixnum:
     dependency: transitive
     description:
@@ -125,18 +125,18 @@ packages:
     dependency: transitive
     description:
       name: glob
-      sha256: "4515b5b6ddb505ebdd242a5f2cc5d22d3d6a80013789debfbda7777f47ea308c"
+      sha256: "0e7014b3b7d4dac1ca4d6114f82bf1782ee86745b9b42a92c9289c23d8a0ab63"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   http:
     dependency: "direct main"
     description:
       name: http
-      sha256: "6aa2946395183537c8b880962d935877325d6a09a2867c3970c05c0fed6ac482"
+      sha256: "5895291c13fa8a3bd82e76d5627f69e0d85ca6a30dcac95c4ea19a5d555879c2"
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.5"
+    version: "0.13.6"
   http_parser:
     dependency: transitive
     description:
@@ -157,26 +157,26 @@ packages:
     dependency: "direct dev"
     description:
       name: lints
-      sha256: "5e4a9cd06d447758280a8ac2405101e0e2094d2a1dbdd3756aec3fe7775ba593"
+      sha256: "0a217c6c989d21039f1498c3ed9f3ed71b354e69873f13a8dfc3c9fe76f1b452"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.1.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.15"
+    version: "0.12.16"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.11.0"
   package_config:
     dependency: transitive
     description:
@@ -197,42 +197,42 @@ packages:
     dependency: transitive
     description:
       name: pointycastle
-      sha256: c3120a968135aead39699267f4c74bc9a08e4e909e86bc1b0af5bfd78691123c
+      sha256: "7c1e5f0d23c9016c5bbd8b1473d0d3fb3fc851b876046039509e18e0c7485f2c"
       url: "https://pub.dev"
     source: hosted
-    version: "3.7.2"
+    version: "3.7.3"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
-      sha256: "307de764d305289ff24ad257ad5c5793ce56d04947599ad68b3baa124105fc17"
+      sha256: "40d3ab1bbd474c4c2328c91e3a7df8c6dd629b79ece4c4bd04bee496a224fb0c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.4"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
@@ -253,33 +253,33 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.6.1"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      sha256: "26f87ade979c47a150c9eaab93ccd2bebe70a27dc0b4b29517f2904f04eb11a5"
+      sha256: facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.2"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      sha256: "6a7f46926b01ce81bfc339da6a7f20afbe7733eff9846f6d6a5466aa4c6667c0"
+      sha256: "3d2ad6751b3c16cf07c7fca317a1413b3f26530319181b37e3b9039b84fc01d8"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.1.0"
   yaml:
     dependency: transitive
     description:
       name: yaml
-      sha256: "23812a9b125b48d4007117254bca50abb6c712352927eece9e155207b1db2370"
+      sha256: "75769501ea3489fca56601ff33454fe45507ea3bfb014161abc3b43ae25989d5"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.2"
 sdks:
-  dart: ">=2.19.0 <3.0.0"
+  dart: ">=3.0.0 <4.0.0"

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -26,6 +26,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/example/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>9.0</string>
+  <string>11.0</string>
 </dict>
 </plist>

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -127,7 +127,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1020;
+				LastUpgradeCheck = 1430;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
@@ -171,10 +171,12 @@
 /* Begin PBXShellScriptBuildPhase section */
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
+				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
 			);
 			name = "Thin Binary";
 			outputPaths = (
@@ -185,6 +187,7 @@
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -272,7 +275,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -354,7 +357,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -403,7 +406,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;

--- a/example/ios/Runner.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/example/ios/Runner.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "group:Runner.xcodeproj">
+      location = "self:">
    </FileRef>
 </Workspace>

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -41,5 +41,9 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 </dict>
 </plist>

--- a/example/lib/constants/all_icons.dart
+++ b/example/lib/constants/all_icons.dart
@@ -5,7 +5,9 @@ import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 abstract class AllIcons {
   static List<PhosphorIconData> get icons => allFlatIconsAsMap.values.toList();
+
   static List<String> get names => allFlatIconsAsMap.keys.toList();
+
   static Map<String, PhosphorIconData> get allFlatIconsAsMap => {
         ...regularIcons,
         ...thinIcons,
@@ -14,6 +16,7 @@ abstract class AllIcons {
         ...fillIcons,
         ...duotoneIcons,
       };
+
   static Map<String, PhosphorIconData> get regularIcons => {
         'address-book': PhosphorIcons.addressBook(PhosphorIconsStyle.regular),
         'airplane': PhosphorIcons.airplane(PhosphorIconsStyle.regular),
@@ -1654,6 +1657,7 @@ abstract class AllIcons {
         'yin-yang': PhosphorIcons.yinYang(PhosphorIconsStyle.regular),
         'youtube-logo': PhosphorIcons.youtubeLogo(PhosphorIconsStyle.regular)
       };
+
   static Map<String, PhosphorIconData> get thinIcons => {
         'address-book': PhosphorIcons.addressBook(PhosphorIconsStyle.thin),
         'airplane': PhosphorIcons.airplane(PhosphorIconsStyle.thin),
@@ -3219,6 +3223,7 @@ abstract class AllIcons {
         'yin-yang': PhosphorIcons.yinYang(PhosphorIconsStyle.thin),
         'youtube-logo': PhosphorIcons.youtubeLogo(PhosphorIconsStyle.thin)
       };
+
   static Map<String, PhosphorIconData> get lightIcons => {
         'address-book': PhosphorIcons.addressBook(PhosphorIconsStyle.light),
         'airplane': PhosphorIcons.airplane(PhosphorIconsStyle.light),
@@ -4801,6 +4806,7 @@ abstract class AllIcons {
         'yin-yang': PhosphorIcons.yinYang(PhosphorIconsStyle.light),
         'youtube-logo': PhosphorIcons.youtubeLogo(PhosphorIconsStyle.light)
       };
+
   static Map<String, PhosphorIconData> get boldIcons => {
         'address-book': PhosphorIcons.addressBook(PhosphorIconsStyle.bold),
         'airplane': PhosphorIcons.airplane(PhosphorIconsStyle.bold),
@@ -6366,6 +6372,7 @@ abstract class AllIcons {
         'yin-yang': PhosphorIcons.yinYang(PhosphorIconsStyle.bold),
         'youtube-logo': PhosphorIcons.youtubeLogo(PhosphorIconsStyle.bold)
       };
+
   static Map<String, PhosphorIconData> get fillIcons => {
         'address-book': PhosphorIcons.addressBook(PhosphorIconsStyle.fill),
         'airplane': PhosphorIcons.airplane(PhosphorIconsStyle.fill),
@@ -7931,6 +7938,7 @@ abstract class AllIcons {
         'yin-yang': PhosphorIcons.yinYang(PhosphorIconsStyle.fill),
         'youtube-logo': PhosphorIcons.youtubeLogo(PhosphorIconsStyle.fill)
       };
+
   static Map<String, PhosphorIconData> get duotoneIcons => {
         'address-book': PhosphorIcons.addressBook(PhosphorIconsStyle.duotone),
         'airplane': PhosphorIcons.airplane(PhosphorIconsStyle.duotone),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -18,7 +18,7 @@ class _MyApp extends StatelessWidget {
 }
 
 class IconsCatalog extends StatefulWidget {
-  const IconsCatalog({Key key}) : super(key: key);
+  const IconsCatalog({super.key});
 
   @override
   State<IconsCatalog> createState() => _IconsCatalogState();
@@ -26,7 +26,7 @@ class IconsCatalog extends StatefulWidget {
 
 class _IconsCatalogState extends State<IconsCatalog> {
   dynamic _icons;
-  List<String> _iconsNames;
+  late List<String> _iconsNames;
   String _title = 'Icons Catalog - Regular';
 
   @override
@@ -80,8 +80,8 @@ class _IconsCatalogState extends State<IconsCatalog> {
               }).toList();
             },
             onSelected: (value) {
-              List<PhosphorIconData> icons;
-              List<String> iconsNames;
+              List<PhosphorIconData> icons = [];
+              List<String> iconsNames = [];
 
               switch (value) {
                 case 'Regular':

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -25,9 +25,9 @@ class IconsCatalog extends StatefulWidget {
 }
 
 class _IconsCatalogState extends State<IconsCatalog> {
-  dynamic _icons;
+  late List<PhosphorIconData> _icons;
   late List<String> _iconsNames;
-  String _title = 'Icons Catalog - Regular';
+  String _title = 'Icons Catalog - regular';
 
   @override
   void initState() {
@@ -57,63 +57,56 @@ class _IconsCatalogState extends State<IconsCatalog> {
         centerTitle: true,
         backgroundColor: const Color(0xff35313d),
         actions: [
-          PopupMenuButton<String>(
+          PopupMenuButton<PhosphorIconsStyle>(
             tooltip: 'Style',
             icon: Icon(PhosphorIcons.pencilLine(PhosphorIconsStyle.regular)),
-            itemBuilder: (context) {
-              return PhosphorIconsStyle.values.map((style) {
-                PhosphorIconData icon = PhosphorIcons.pencilLine(style);
-
-                return PopupMenuItem<String>(
-                  value: style.name,
-                  child: Row(
-                    children: [
-                      PhosphorIcon(
-                        icon,
-                        color: Colors.black,
+            itemBuilder: (context) => PhosphorIconsStyle.values
+                .map((style) => PopupMenuItem<PhosphorIconsStyle>(
+                      value: style,
+                      child: Row(
+                        children: [
+                          PhosphorIcon(
+                            PhosphorIcons.pencilLine(style),
+                            color: Colors.black,
+                          ),
+                          const SizedBox(width: 8),
+                          Text(style.name),
+                        ],
                       ),
-                      const SizedBox(width: 8),
-                      Text(style.name),
-                    ],
-                  ),
-                );
-              }).toList();
-            },
+                    ))
+                .toList(),
             onSelected: (value) {
-              List<PhosphorIconData> icons = [];
-              List<String> iconsNames = [];
-
-              switch (value) {
-                case 'Regular':
-                  icons = AllIcons.regularIcons.values.toList();
-                  iconsNames = AllIcons.regularIcons.keys.toList();
-                  break;
-                case 'Thin':
-                  icons = AllIcons.thinIcons.values.toList();
-                  iconsNames = AllIcons.thinIcons.keys.toList();
-                  break;
-                case 'Light':
-                  icons = AllIcons.lightIcons.values.toList();
-                  iconsNames = AllIcons.lightIcons.keys.toList();
-                  break;
-                case 'Bold':
-                  icons = AllIcons.boldIcons.values.toList();
-                  iconsNames = AllIcons.boldIcons.keys.toList();
-                  break;
-                case 'Fill':
-                  icons = AllIcons.fillIcons.values.toList();
-                  iconsNames = AllIcons.fillIcons.keys.toList();
-                  break;
-                case 'Duotone':
-                  icons = AllIcons.duotoneIcons.values.toList();
-                  iconsNames = AllIcons.duotoneIcons.keys.toList();
-                  break;
-              }
+              final (icons, names) = switch (value) {
+                PhosphorIconsStyle.regular => (
+                    AllIcons.regularIcons.values.toList(),
+                    AllIcons.regularIcons.keys.toList()
+                  ),
+                PhosphorIconsStyle.thin => (
+                    AllIcons.thinIcons.values.toList(),
+                    AllIcons.thinIcons.keys.toList()
+                  ),
+                PhosphorIconsStyle.light => (
+                    AllIcons.lightIcons.values.toList(),
+                    AllIcons.lightIcons.keys.toList()
+                  ),
+                PhosphorIconsStyle.bold => (
+                    AllIcons.boldIcons.values.toList(),
+                    AllIcons.boldIcons.keys.toList()
+                  ),
+                PhosphorIconsStyle.fill => (
+                    AllIcons.fillIcons.values.toList(),
+                    AllIcons.fillIcons.keys.toList()
+                  ),
+                PhosphorIconsStyle.duotone => (
+                    AllIcons.duotoneIcons.values.toList(),
+                    AllIcons.duotoneIcons.keys.toList()
+                  ),
+              };
 
               setState(() {
                 _icons = icons;
-                _iconsNames = iconsNames;
-                _title = 'Icons Catalog - $value';
+                _iconsNames = names;
+                _title = 'Icons Catalog - ${value.name}';
               });
             },
           ),
@@ -134,13 +127,10 @@ class _IconsCatalogState extends State<IconsCatalog> {
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
-                if (_icons is List<PhosphorIconData>)
-                  PhosphorIcon(
-                    _icons[index],
-                    size: 48,
-                  )
-                else
+                PhosphorIcon(
                   _icons[index],
+                  size: 48,
+                ),
                 Text(
                   _iconsNames[index],
                   textAlign: TextAlign.center,

--- a/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/example/macos/Runner.xcodeproj/project.pbxproj
@@ -182,7 +182,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0920;
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1430;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					33CC10EC2044A3C60003C045 = {

--- a/example/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.17.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -34,10 +34,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.7"
   lints:
     dependency: transitive
     description:
@@ -58,10 +58,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.1"
   phosphor_flutter:
     dependency: "direct main"
     description:
@@ -83,5 +83,5 @@ packages:
     source: hosted
     version: "2.1.4"
 sdks:
-  dart: ">=2.17.0 <3.0.0"
+  dart: ">=3.0.0 <4.0.0"
   flutter: ">=1.17.0"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.1"
+    version: "1.18.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -30,14 +30,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.7"
   lints:
     dependency: transitive
     description:
@@ -50,25 +42,25 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.11.0"
   phosphor_flutter:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "2.0.0"
+    version: "2.0.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -82,6 +74,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4-beta"
 sdks:
-  dart: ">=3.0.0 <4.0.0"
-  flutter: ">=3.3.0"
+  dart: ">=3.1.0-185.0.dev <4.0.0"
+  flutter: ">=1.17.0"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -84,4 +84,4 @@ packages:
     version: "2.1.4"
 sdks:
   dart: ">=3.0.0 <4.0.0"
-  flutter: ">=1.17.0"
+  flutter: ">=3.3.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: Catalog of icons showing a preview of them.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   flutter:

--- a/lib/src/phosphor_icon.dart
+++ b/lib/src/phosphor_icon.dart
@@ -27,6 +27,7 @@ class PhosphorIcon extends Icon {
     if (icon is PhosphorDuotoneIconData) {
       final duotoneIcon = icon as PhosphorDuotoneIconData;
       return Stack(
+        alignment: Alignment.center,
         children: [
           Opacity(
             opacity: duotoneSecondaryOpacity,

--- a/lib/src/phosphor_icon.dart
+++ b/lib/src/phosphor_icon.dart
@@ -3,25 +3,22 @@ library phosphor_flutter;
 import 'package:flutter/material.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
-class PhosphorIcon extends StatelessWidget {
+class PhosphorIcon extends Icon {
   const PhosphorIcon(
-    this.icon, {
-    Key? key,
-    this.color,
-    this.semanticLabel,
-    this.shadows,
-    this.size,
-    this.textDirection,
-    this.duotoneSecondaryOpacity = 0.20,
-    this.duotoneSecondaryColor,
-  }) : super(key: key);
-
-  final PhosphorIconData icon;
-  final Color? color;
-  final String? semanticLabel;
-  final List<Shadow>? shadows;
-  final double? size;
-  final TextDirection? textDirection;
+      super.icon, {
+        super.key,
+        super.size,
+        super.fill,
+        super.weight,
+        super.grade,
+        super.opticalSize,
+        super.color,
+        super.shadows,
+        super.semanticLabel,
+        super.textDirection,
+        this.duotoneSecondaryOpacity = 0.20,
+        this.duotoneSecondaryColor,
+      });
   final double duotoneSecondaryOpacity;
   final Color? duotoneSecondaryColor;
 
@@ -34,32 +31,35 @@ class PhosphorIcon extends StatelessWidget {
           Opacity(
             opacity: duotoneSecondaryOpacity,
             child: Icon(
-              duotoneIcon.secondary,
-              color: duotoneSecondaryColor ?? color,
-              semanticLabel: semanticLabel,
-              shadows: shadows,
+              key: key,
               size: size,
+              fill: fill,
+              weight: weight,
+              grade: grade,
+              opticalSize: opticalSize,
+              color: duotoneSecondaryColor ?? color,
+              shadows: shadows,
+              semanticLabel: semanticLabel,
               textDirection: textDirection,
+              duotoneIcon.secondary,
             ),
           ),
           Icon(
             duotoneIcon,
-            color: color,
-            semanticLabel: semanticLabel,
-            shadows: shadows,
+            key: key,
             size: size,
+            fill: fill,
+            weight: weight,
+            grade: grade,
+            opticalSize: opticalSize,
+            color: color,
+            shadows: shadows,
+            semanticLabel: semanticLabel,
             textDirection: textDirection,
           ),
         ],
       );
     }
-    return Icon(
-      icon,
-      color: color,
-      semanticLabel: semanticLabel,
-      shadows: shadows,
-      size: size,
-      textDirection: textDirection,
-    );
+    return super.build(context);
   }
 }

--- a/lib/src/phosphor_icon.dart
+++ b/lib/src/phosphor_icon.dart
@@ -5,20 +5,33 @@ import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 class PhosphorIcon extends Icon {
   const PhosphorIcon(
-    super.icon, {
-    super.key,
-    super.size,
-    super.fill,
-    super.weight,
-    super.grade,
-    super.opticalSize,
-    super.color,
-    super.shadows,
-    super.semanticLabel,
-    super.textDirection,
+    IconData icon, {
+    Key? key,
+    double? size,
+    double? fill,
+    double? weight,
+    double? grade,
+    double? opticalSize,
+    Color? color,
+    List<Shadow>? shadows,
+    String? semanticLabel,
+    TextDirection? textDirection,
     this.duotoneSecondaryOpacity = 0.20,
     this.duotoneSecondaryColor,
-  });
+  }) : super(
+          icon,
+          color: color,
+          fill: fill,
+          grade: grade,
+          key: key,
+          opticalSize: opticalSize,
+          semanticLabel: semanticLabel,
+          shadows: shadows,
+          size: size,
+          textDirection: textDirection,
+          weight: weight,
+        );
+
   final double duotoneSecondaryOpacity;
   final Color? duotoneSecondaryColor;
 
@@ -32,6 +45,7 @@ class PhosphorIcon extends Icon {
           Opacity(
             opacity: duotoneSecondaryOpacity,
             child: Icon(
+              duotoneIcon.secondary,
               key: key,
               size: size,
               fill: fill,
@@ -42,7 +56,6 @@ class PhosphorIcon extends Icon {
               shadows: shadows,
               semanticLabel: semanticLabel,
               textDirection: textDirection,
-              duotoneIcon.secondary,
             ),
           ),
           super.build(context),

--- a/lib/src/phosphor_icon.dart
+++ b/lib/src/phosphor_icon.dart
@@ -5,20 +5,20 @@ import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 class PhosphorIcon extends Icon {
   const PhosphorIcon(
-      super.icon, {
-        super.key,
-        super.size,
-        super.fill,
-        super.weight,
-        super.grade,
-        super.opticalSize,
-        super.color,
-        super.shadows,
-        super.semanticLabel,
-        super.textDirection,
-        this.duotoneSecondaryOpacity = 0.20,
-        this.duotoneSecondaryColor,
-      });
+    super.icon, {
+    super.key,
+    super.size,
+    super.fill,
+    super.weight,
+    super.grade,
+    super.opticalSize,
+    super.color,
+    super.shadows,
+    super.semanticLabel,
+    super.textDirection,
+    this.duotoneSecondaryOpacity = 0.20,
+    this.duotoneSecondaryColor,
+  });
   final double duotoneSecondaryOpacity;
   final Color? duotoneSecondaryColor;
 

--- a/lib/src/phosphor_icon.dart
+++ b/lib/src/phosphor_icon.dart
@@ -44,19 +44,7 @@ class PhosphorIcon extends Icon {
               duotoneIcon.secondary,
             ),
           ),
-          Icon(
-            duotoneIcon,
-            key: key,
-            size: size,
-            fill: fill,
-            weight: weight,
-            grade: grade,
-            opticalSize: opticalSize,
-            color: color,
-            shadows: shadows,
-            semanticLabel: semanticLabel,
-            textDirection: textDirection,
-          ),
+          super.build(context),
         ],
       );
     }

--- a/lib/src/phosphor_icon_data.dart
+++ b/lib/src/phosphor_icon_data.dart
@@ -19,7 +19,7 @@ class PhosphorFlatIconData extends PhosphorIconData {
 
 class PhosphorDuotoneIconData extends PhosphorIconData {
   const PhosphorDuotoneIconData(int codePoint, this.secondary)
-      : super(codePoint, 'duotone');
+      : super(codePoint, 'Duotone');
 
   final PhosphorIconData secondary;
 }

--- a/lib/src/phosphor_icons_duotone.dart
+++ b/lib/src/phosphor_icons_duotone.dart
@@ -9,1615 +9,1615 @@ class PhosphorIconsDuotone {
   /// ![address-book-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/address-book-duotone.svg)
   static const addressBook = PhosphorDuotoneIconData(
     0xe901,
-    PhosphorIconData(0xe900, 'duotone'),
+    PhosphorIconData(0xe900, 'Duotone'),
   );
 
   /// ![air-traffic-control-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/air-traffic-control-duotone.svg)
   static const airTrafficControl = PhosphorDuotoneIconData(
     0xe90f,
-    PhosphorIconData(0xe90e, 'duotone'),
+    PhosphorIconData(0xe90e, 'Duotone'),
   );
 
   /// ![airplane-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/airplane-duotone.svg)
   static const airplane = PhosphorDuotoneIconData(
     0xe903,
-    PhosphorIconData(0xe902, 'duotone'),
+    PhosphorIconData(0xe902, 'Duotone'),
   );
 
   /// ![airplane-in-flight-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/airplane-in-flight-duotone.svg)
   static const airplaneInFlight = PhosphorDuotoneIconData(
     0xe905,
-    PhosphorIconData(0xe904, 'duotone'),
+    PhosphorIconData(0xe904, 'Duotone'),
   );
 
   /// ![airplane-landing-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/airplane-landing-duotone.svg)
   static const airplaneLanding = PhosphorDuotoneIconData(
     0xe907,
-    PhosphorIconData(0xe906, 'duotone'),
+    PhosphorIconData(0xe906, 'Duotone'),
   );
 
   /// ![airplane-takeoff-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/airplane-takeoff-duotone.svg)
   static const airplaneTakeoff = PhosphorDuotoneIconData(
     0xe909,
-    PhosphorIconData(0xe908, 'duotone'),
+    PhosphorIconData(0xe908, 'Duotone'),
   );
 
   /// ![airplane-tilt-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/airplane-tilt-duotone.svg)
   static const airplaneTilt = PhosphorDuotoneIconData(
     0xe90b,
-    PhosphorIconData(0xe90a, 'duotone'),
+    PhosphorIconData(0xe90a, 'Duotone'),
   );
 
   /// ![airplay-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/airplay-duotone.svg)
   static const airplay = PhosphorDuotoneIconData(
     0xe90d,
-    PhosphorIconData(0xe90c, 'duotone'),
+    PhosphorIconData(0xe90c, 'Duotone'),
   );
 
   /// ![alarm-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/alarm-duotone.svg)
   static const alarm = PhosphorDuotoneIconData(
     0xe911,
-    PhosphorIconData(0xe910, 'duotone'),
+    PhosphorIconData(0xe910, 'Duotone'),
   );
 
   /// ![alien-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/alien-duotone.svg)
   static const alien = PhosphorDuotoneIconData(
     0xe913,
-    PhosphorIconData(0xe912, 'duotone'),
+    PhosphorIconData(0xe912, 'Duotone'),
   );
 
   /// ![align-bottom-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/align-bottom-duotone.svg)
   static const alignBottom = PhosphorDuotoneIconData(
     0xe915,
-    PhosphorIconData(0xe914, 'duotone'),
+    PhosphorIconData(0xe914, 'Duotone'),
   );
 
   /// ![align-bottom-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/align-bottom-simple-duotone.svg)
   static const alignBottomSimple = PhosphorDuotoneIconData(
     0xe917,
-    PhosphorIconData(0xe916, 'duotone'),
+    PhosphorIconData(0xe916, 'Duotone'),
   );
 
   /// ![align-center-horizontal-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/align-center-horizontal-duotone.svg)
   static const alignCenterHorizontal = PhosphorDuotoneIconData(
     0xe919,
-    PhosphorIconData(0xe918, 'duotone'),
+    PhosphorIconData(0xe918, 'Duotone'),
   );
 
   /// ![align-center-horizontal-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/align-center-horizontal-simple-duotone.svg)
   static const alignCenterHorizontalSimple = PhosphorDuotoneIconData(
     0xe91b,
-    PhosphorIconData(0xe91a, 'duotone'),
+    PhosphorIconData(0xe91a, 'Duotone'),
   );
 
   /// ![align-center-vertical-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/align-center-vertical-duotone.svg)
   static const alignCenterVertical = PhosphorDuotoneIconData(
     0xe91d,
-    PhosphorIconData(0xe91c, 'duotone'),
+    PhosphorIconData(0xe91c, 'Duotone'),
   );
 
   /// ![align-center-vertical-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/align-center-vertical-simple-duotone.svg)
   static const alignCenterVerticalSimple = PhosphorDuotoneIconData(
     0xe91f,
-    PhosphorIconData(0xe91e, 'duotone'),
+    PhosphorIconData(0xe91e, 'Duotone'),
   );
 
   /// ![align-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/align-left-duotone.svg)
   static const alignLeft = PhosphorDuotoneIconData(
     0xe921,
-    PhosphorIconData(0xe920, 'duotone'),
+    PhosphorIconData(0xe920, 'Duotone'),
   );
 
   /// ![align-left-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/align-left-simple-duotone.svg)
   static const alignLeftSimple = PhosphorDuotoneIconData(
     0xe923,
-    PhosphorIconData(0xe922, 'duotone'),
+    PhosphorIconData(0xe922, 'Duotone'),
   );
 
   /// ![align-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/align-right-duotone.svg)
   static const alignRight = PhosphorDuotoneIconData(
     0xe925,
-    PhosphorIconData(0xe924, 'duotone'),
+    PhosphorIconData(0xe924, 'Duotone'),
   );
 
   /// ![align-right-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/align-right-simple-duotone.svg)
   static const alignRightSimple = PhosphorDuotoneIconData(
     0xe927,
-    PhosphorIconData(0xe926, 'duotone'),
+    PhosphorIconData(0xe926, 'Duotone'),
   );
 
   /// ![align-top-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/align-top-duotone.svg)
   static const alignTop = PhosphorDuotoneIconData(
     0xe929,
-    PhosphorIconData(0xe928, 'duotone'),
+    PhosphorIconData(0xe928, 'Duotone'),
   );
 
   /// ![align-top-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/align-top-simple-duotone.svg)
   static const alignTopSimple = PhosphorDuotoneIconData(
     0xe92b,
-    PhosphorIconData(0xe92a, 'duotone'),
+    PhosphorIconData(0xe92a, 'Duotone'),
   );
 
   /// ![amazon-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/amazon-logo-duotone.svg)
   static const amazonLogo = PhosphorDuotoneIconData(
     0xe92d,
-    PhosphorIconData(0xe92c, 'duotone'),
+    PhosphorIconData(0xe92c, 'Duotone'),
   );
 
   /// ![anchor-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/anchor-duotone.svg)
   static const anchor = PhosphorDuotoneIconData(
     0xe92f,
-    PhosphorIconData(0xe92e, 'duotone'),
+    PhosphorIconData(0xe92e, 'Duotone'),
   );
 
   /// ![anchor-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/anchor-simple-duotone.svg)
   static const anchorSimple = PhosphorDuotoneIconData(
     0xe931,
-    PhosphorIconData(0xe930, 'duotone'),
+    PhosphorIconData(0xe930, 'Duotone'),
   );
 
   /// ![android-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/android-logo-duotone.svg)
   static const androidLogo = PhosphorDuotoneIconData(
     0xe933,
-    PhosphorIconData(0xe932, 'duotone'),
+    PhosphorIconData(0xe932, 'Duotone'),
   );
 
   /// ![angular-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/angular-logo-duotone.svg)
   static const angularLogo = PhosphorDuotoneIconData(
     0xe935,
-    PhosphorIconData(0xe934, 'duotone'),
+    PhosphorIconData(0xe934, 'Duotone'),
   );
 
   /// ![aperture-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/aperture-duotone.svg)
   static const aperture = PhosphorDuotoneIconData(
     0xe937,
-    PhosphorIconData(0xe936, 'duotone'),
+    PhosphorIconData(0xe936, 'Duotone'),
   );
 
   /// ![app-store-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/app-store-logo-duotone.svg)
   static const appStoreLogo = PhosphorDuotoneIconData(
     0xe93d,
-    PhosphorIconData(0xe93c, 'duotone'),
+    PhosphorIconData(0xe93c, 'Duotone'),
   );
 
   /// ![app-window-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/app-window-duotone.svg)
   static const appWindow = PhosphorDuotoneIconData(
     0xe93f,
-    PhosphorIconData(0xe93e, 'duotone'),
+    PhosphorIconData(0xe93e, 'Duotone'),
   );
 
   /// ![apple-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/apple-logo-duotone.svg)
   static const appleLogo = PhosphorDuotoneIconData(
     0xe939,
-    PhosphorIconData(0xe938, 'duotone'),
+    PhosphorIconData(0xe938, 'Duotone'),
   );
 
   /// ![apple-podcasts-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/apple-podcasts-logo-duotone.svg)
   static const applePodcastsLogo = PhosphorDuotoneIconData(
     0xe93b,
-    PhosphorIconData(0xe93a, 'duotone'),
+    PhosphorIconData(0xe93a, 'Duotone'),
   );
 
   /// ![archive-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/archive-duotone.svg)
   static const archive = PhosphorDuotoneIconData(
     0xe943,
-    PhosphorIconData(0xe942, 'duotone'),
+    PhosphorIconData(0xe942, 'Duotone'),
   );
 
   /// ![archive-box-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/archive-box-duotone.svg)
   static const archiveBox = PhosphorDuotoneIconData(
     0xe941,
-    PhosphorIconData(0xe940, 'duotone'),
+    PhosphorIconData(0xe940, 'Duotone'),
   );
 
   /// ![archive-tray-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/archive-tray-duotone.svg)
   static const archiveTray = PhosphorDuotoneIconData(
     0xe945,
-    PhosphorIconData(0xe944, 'duotone'),
+    PhosphorIconData(0xe944, 'Duotone'),
   );
 
   /// ![armchair-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/armchair-duotone.svg)
   static const armchair = PhosphorDuotoneIconData(
     0xe947,
-    PhosphorIconData(0xe946, 'duotone'),
+    PhosphorIconData(0xe946, 'Duotone'),
   );
 
   /// ![arrow-arc-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-arc-left-duotone.svg)
   static const arrowArcLeft = PhosphorDuotoneIconData(
     0xe949,
-    PhosphorIconData(0xe948, 'duotone'),
+    PhosphorIconData(0xe948, 'Duotone'),
   );
 
   /// ![arrow-arc-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-arc-right-duotone.svg)
   static const arrowArcRight = PhosphorDuotoneIconData(
     0xe94b,
-    PhosphorIconData(0xe94a, 'duotone'),
+    PhosphorIconData(0xe94a, 'Duotone'),
   );
 
   /// ![arrow-bend-double-up-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-bend-double-up-left-duotone.svg)
   static const arrowBendDoubleUpLeft = PhosphorDuotoneIconData(
     0xe94d,
-    PhosphorIconData(0xe94c, 'duotone'),
+    PhosphorIconData(0xe94c, 'Duotone'),
   );
 
   /// ![arrow-bend-double-up-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-bend-double-up-right-duotone.svg)
   static const arrowBendDoubleUpRight = PhosphorDuotoneIconData(
     0xe94f,
-    PhosphorIconData(0xe94e, 'duotone'),
+    PhosphorIconData(0xe94e, 'Duotone'),
   );
 
   /// ![arrow-bend-down-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-bend-down-left-duotone.svg)
   static const arrowBendDownLeft = PhosphorDuotoneIconData(
     0xe951,
-    PhosphorIconData(0xe950, 'duotone'),
+    PhosphorIconData(0xe950, 'Duotone'),
   );
 
   /// ![arrow-bend-down-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-bend-down-right-duotone.svg)
   static const arrowBendDownRight = PhosphorDuotoneIconData(
     0xe953,
-    PhosphorIconData(0xe952, 'duotone'),
+    PhosphorIconData(0xe952, 'Duotone'),
   );
 
   /// ![arrow-bend-left-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-bend-left-down-duotone.svg)
   static const arrowBendLeftDown = PhosphorDuotoneIconData(
     0xe955,
-    PhosphorIconData(0xe954, 'duotone'),
+    PhosphorIconData(0xe954, 'Duotone'),
   );
 
   /// ![arrow-bend-left-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-bend-left-up-duotone.svg)
   static const arrowBendLeftUp = PhosphorDuotoneIconData(
     0xe957,
-    PhosphorIconData(0xe956, 'duotone'),
+    PhosphorIconData(0xe956, 'Duotone'),
   );
 
   /// ![arrow-bend-right-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-bend-right-down-duotone.svg)
   static const arrowBendRightDown = PhosphorDuotoneIconData(
     0xe959,
-    PhosphorIconData(0xe958, 'duotone'),
+    PhosphorIconData(0xe958, 'Duotone'),
   );
 
   /// ![arrow-bend-right-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-bend-right-up-duotone.svg)
   static const arrowBendRightUp = PhosphorDuotoneIconData(
     0xe95b,
-    PhosphorIconData(0xe95a, 'duotone'),
+    PhosphorIconData(0xe95a, 'Duotone'),
   );
 
   /// ![arrow-bend-up-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-bend-up-left-duotone.svg)
   static const arrowBendUpLeft = PhosphorDuotoneIconData(
     0xe95d,
-    PhosphorIconData(0xe95c, 'duotone'),
+    PhosphorIconData(0xe95c, 'Duotone'),
   );
 
   /// ![arrow-bend-up-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-bend-up-right-duotone.svg)
   static const arrowBendUpRight = PhosphorDuotoneIconData(
     0xe95f,
-    PhosphorIconData(0xe95e, 'duotone'),
+    PhosphorIconData(0xe95e, 'Duotone'),
   );
 
   /// ![arrow-circle-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-circle-down-duotone.svg)
   static const arrowCircleDown = PhosphorDuotoneIconData(
     0xe961,
-    PhosphorIconData(0xe960, 'duotone'),
+    PhosphorIconData(0xe960, 'Duotone'),
   );
 
   /// ![arrow-circle-down-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-circle-down-left-duotone.svg)
   static const arrowCircleDownLeft = PhosphorDuotoneIconData(
     0xe963,
-    PhosphorIconData(0xe962, 'duotone'),
+    PhosphorIconData(0xe962, 'Duotone'),
   );
 
   /// ![arrow-circle-down-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-circle-down-right-duotone.svg)
   static const arrowCircleDownRight = PhosphorDuotoneIconData(
     0xe965,
-    PhosphorIconData(0xe964, 'duotone'),
+    PhosphorIconData(0xe964, 'Duotone'),
   );
 
   /// ![arrow-circle-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-circle-left-duotone.svg)
   static const arrowCircleLeft = PhosphorDuotoneIconData(
     0xe967,
-    PhosphorIconData(0xe966, 'duotone'),
+    PhosphorIconData(0xe966, 'Duotone'),
   );
 
   /// ![arrow-circle-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-circle-right-duotone.svg)
   static const arrowCircleRight = PhosphorDuotoneIconData(
     0xe969,
-    PhosphorIconData(0xe968, 'duotone'),
+    PhosphorIconData(0xe968, 'Duotone'),
   );
 
   /// ![arrow-circle-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-circle-up-duotone.svg)
   static const arrowCircleUp = PhosphorDuotoneIconData(
     0xe96b,
-    PhosphorIconData(0xe96a, 'duotone'),
+    PhosphorIconData(0xe96a, 'Duotone'),
   );
 
   /// ![arrow-circle-up-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-circle-up-left-duotone.svg)
   static const arrowCircleUpLeft = PhosphorDuotoneIconData(
     0xe96d,
-    PhosphorIconData(0xe96c, 'duotone'),
+    PhosphorIconData(0xe96c, 'Duotone'),
   );
 
   /// ![arrow-circle-up-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-circle-up-right-duotone.svg)
   static const arrowCircleUpRight = PhosphorDuotoneIconData(
     0xe96f,
-    PhosphorIconData(0xe96e, 'duotone'),
+    PhosphorIconData(0xe96e, 'Duotone'),
   );
 
   /// ![arrow-clockwise-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-clockwise-duotone.svg)
   static const arrowClockwise = PhosphorDuotoneIconData(
     0xe971,
-    PhosphorIconData(0xe970, 'duotone'),
+    PhosphorIconData(0xe970, 'Duotone'),
   );
 
   /// ![arrow-counter-clockwise-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-counter-clockwise-duotone.svg)
   static const arrowCounterClockwise = PhosphorDuotoneIconData(
     0xe973,
-    PhosphorIconData(0xe972, 'duotone'),
+    PhosphorIconData(0xe972, 'Duotone'),
   );
 
   /// ![arrow-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-down-duotone.svg)
   static const arrowDown = PhosphorDuotoneIconData(
     0xe975,
-    PhosphorIconData(0xe974, 'duotone'),
+    PhosphorIconData(0xe974, 'Duotone'),
   );
 
   /// ![arrow-down-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-down-left-duotone.svg)
   static const arrowDownLeft = PhosphorDuotoneIconData(
     0xe977,
-    PhosphorIconData(0xe976, 'duotone'),
+    PhosphorIconData(0xe976, 'Duotone'),
   );
 
   /// ![arrow-down-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-down-right-duotone.svg)
   static const arrowDownRight = PhosphorDuotoneIconData(
     0xe979,
-    PhosphorIconData(0xe978, 'duotone'),
+    PhosphorIconData(0xe978, 'Duotone'),
   );
 
   /// ![arrow-elbow-down-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-elbow-down-left-duotone.svg)
   static const arrowElbowDownLeft = PhosphorDuotoneIconData(
     0xe97b,
-    PhosphorIconData(0xe97a, 'duotone'),
+    PhosphorIconData(0xe97a, 'Duotone'),
   );
 
   /// ![arrow-elbow-down-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-elbow-down-right-duotone.svg)
   static const arrowElbowDownRight = PhosphorDuotoneIconData(
     0xe97d,
-    PhosphorIconData(0xe97c, 'duotone'),
+    PhosphorIconData(0xe97c, 'Duotone'),
   );
 
   /// ![arrow-elbow-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-elbow-left-duotone.svg)
   static const arrowElbowLeft = PhosphorDuotoneIconData(
     0xe981,
-    PhosphorIconData(0xe980, 'duotone'),
+    PhosphorIconData(0xe980, 'Duotone'),
   );
 
   /// ![arrow-elbow-left-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-elbow-left-down-duotone.svg)
   static const arrowElbowLeftDown = PhosphorDuotoneIconData(
     0xe97f,
-    PhosphorIconData(0xe97e, 'duotone'),
+    PhosphorIconData(0xe97e, 'Duotone'),
   );
 
   /// ![arrow-elbow-left-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-elbow-left-up-duotone.svg)
   static const arrowElbowLeftUp = PhosphorDuotoneIconData(
     0xe983,
-    PhosphorIconData(0xe982, 'duotone'),
+    PhosphorIconData(0xe982, 'Duotone'),
   );
 
   /// ![arrow-elbow-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-elbow-right-duotone.svg)
   static const arrowElbowRight = PhosphorDuotoneIconData(
     0xe987,
-    PhosphorIconData(0xe986, 'duotone'),
+    PhosphorIconData(0xe986, 'Duotone'),
   );
 
   /// ![arrow-elbow-right-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-elbow-right-down-duotone.svg)
   static const arrowElbowRightDown = PhosphorDuotoneIconData(
     0xe985,
-    PhosphorIconData(0xe984, 'duotone'),
+    PhosphorIconData(0xe984, 'Duotone'),
   );
 
   /// ![arrow-elbow-right-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-elbow-right-up-duotone.svg)
   static const arrowElbowRightUp = PhosphorDuotoneIconData(
     0xe989,
-    PhosphorIconData(0xe988, 'duotone'),
+    PhosphorIconData(0xe988, 'Duotone'),
   );
 
   /// ![arrow-elbow-up-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-elbow-up-left-duotone.svg)
   static const arrowElbowUpLeft = PhosphorDuotoneIconData(
     0xe98b,
-    PhosphorIconData(0xe98a, 'duotone'),
+    PhosphorIconData(0xe98a, 'Duotone'),
   );
 
   /// ![arrow-elbow-up-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-elbow-up-right-duotone.svg)
   static const arrowElbowUpRight = PhosphorDuotoneIconData(
     0xe98d,
-    PhosphorIconData(0xe98c, 'duotone'),
+    PhosphorIconData(0xe98c, 'Duotone'),
   );
 
   /// ![arrow-fat-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-fat-down-duotone.svg)
   static const arrowFatDown = PhosphorDuotoneIconData(
     0xe98f,
-    PhosphorIconData(0xe98e, 'duotone'),
+    PhosphorIconData(0xe98e, 'Duotone'),
   );
 
   /// ![arrow-fat-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-fat-left-duotone.svg)
   static const arrowFatLeft = PhosphorDuotoneIconData(
     0xe991,
-    PhosphorIconData(0xe990, 'duotone'),
+    PhosphorIconData(0xe990, 'Duotone'),
   );
 
   /// ![arrow-fat-line-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-fat-line-down-duotone.svg)
   static const arrowFatLineDown = PhosphorDuotoneIconData(
     0xe993,
-    PhosphorIconData(0xe992, 'duotone'),
+    PhosphorIconData(0xe992, 'Duotone'),
   );
 
   /// ![arrow-fat-line-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-fat-line-left-duotone.svg)
   static const arrowFatLineLeft = PhosphorDuotoneIconData(
     0xe995,
-    PhosphorIconData(0xe994, 'duotone'),
+    PhosphorIconData(0xe994, 'Duotone'),
   );
 
   /// ![arrow-fat-line-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-fat-line-right-duotone.svg)
   static const arrowFatLineRight = PhosphorDuotoneIconData(
     0xe997,
-    PhosphorIconData(0xe996, 'duotone'),
+    PhosphorIconData(0xe996, 'Duotone'),
   );
 
   /// ![arrow-fat-line-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-fat-line-up-duotone.svg)
   static const arrowFatLineUp = PhosphorDuotoneIconData(
     0xe9a1,
-    PhosphorIconData(0xe9a0, 'duotone'),
+    PhosphorIconData(0xe9a0, 'Duotone'),
   );
 
   /// ![arrow-fat-lines-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-fat-lines-down-duotone.svg)
   static const arrowFatLinesDown = PhosphorDuotoneIconData(
     0xe999,
-    PhosphorIconData(0xe998, 'duotone'),
+    PhosphorIconData(0xe998, 'Duotone'),
   );
 
   /// ![arrow-fat-lines-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-fat-lines-left-duotone.svg)
   static const arrowFatLinesLeft = PhosphorDuotoneIconData(
     0xe99b,
-    PhosphorIconData(0xe99a, 'duotone'),
+    PhosphorIconData(0xe99a, 'Duotone'),
   );
 
   /// ![arrow-fat-lines-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-fat-lines-right-duotone.svg)
   static const arrowFatLinesRight = PhosphorDuotoneIconData(
     0xe99d,
-    PhosphorIconData(0xe99c, 'duotone'),
+    PhosphorIconData(0xe99c, 'Duotone'),
   );
 
   /// ![arrow-fat-lines-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-fat-lines-up-duotone.svg)
   static const arrowFatLinesUp = PhosphorDuotoneIconData(
     0xe99f,
-    PhosphorIconData(0xe99e, 'duotone'),
+    PhosphorIconData(0xe99e, 'Duotone'),
   );
 
   /// ![arrow-fat-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-fat-right-duotone.svg)
   static const arrowFatRight = PhosphorDuotoneIconData(
     0xe9a3,
-    PhosphorIconData(0xe9a2, 'duotone'),
+    PhosphorIconData(0xe9a2, 'Duotone'),
   );
 
   /// ![arrow-fat-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-fat-up-duotone.svg)
   static const arrowFatUp = PhosphorDuotoneIconData(
     0xe9a5,
-    PhosphorIconData(0xe9a4, 'duotone'),
+    PhosphorIconData(0xe9a4, 'Duotone'),
   );
 
   /// ![arrow-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-left-duotone.svg)
   static const arrowLeft = PhosphorDuotoneIconData(
     0xe9a7,
-    PhosphorIconData(0xe9a6, 'duotone'),
+    PhosphorIconData(0xe9a6, 'Duotone'),
   );
 
   /// ![arrow-line-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-line-down-duotone.svg)
   static const arrowLineDown = PhosphorDuotoneIconData(
     0xe9a9,
-    PhosphorIconData(0xe9a8, 'duotone'),
+    PhosphorIconData(0xe9a8, 'Duotone'),
   );
 
   /// ![arrow-line-down-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-line-down-left-duotone.svg)
   static const arrowLineDownLeft = PhosphorDuotoneIconData(
     0xe9ab,
-    PhosphorIconData(0xe9aa, 'duotone'),
+    PhosphorIconData(0xe9aa, 'Duotone'),
   );
 
   /// ![arrow-line-down-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-line-down-right-duotone.svg)
   static const arrowLineDownRight = PhosphorDuotoneIconData(
     0xe9ad,
-    PhosphorIconData(0xe9ac, 'duotone'),
+    PhosphorIconData(0xe9ac, 'Duotone'),
   );
 
   /// ![arrow-line-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-line-left-duotone.svg)
   static const arrowLineLeft = PhosphorDuotoneIconData(
     0xe9af,
-    PhosphorIconData(0xe9ae, 'duotone'),
+    PhosphorIconData(0xe9ae, 'Duotone'),
   );
 
   /// ![arrow-line-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-line-right-duotone.svg)
   static const arrowLineRight = PhosphorDuotoneIconData(
     0xe9b1,
-    PhosphorIconData(0xe9b0, 'duotone'),
+    PhosphorIconData(0xe9b0, 'Duotone'),
   );
 
   /// ![arrow-line-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-line-up-duotone.svg)
   static const arrowLineUp = PhosphorDuotoneIconData(
     0xe9b3,
-    PhosphorIconData(0xe9b2, 'duotone'),
+    PhosphorIconData(0xe9b2, 'Duotone'),
   );
 
   /// ![arrow-line-up-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-line-up-left-duotone.svg)
   static const arrowLineUpLeft = PhosphorDuotoneIconData(
     0xe9b5,
-    PhosphorIconData(0xe9b4, 'duotone'),
+    PhosphorIconData(0xe9b4, 'Duotone'),
   );
 
   /// ![arrow-line-up-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-line-up-right-duotone.svg)
   static const arrowLineUpRight = PhosphorDuotoneIconData(
     0xe9b7,
-    PhosphorIconData(0xe9b6, 'duotone'),
+    PhosphorIconData(0xe9b6, 'Duotone'),
   );
 
   /// ![arrow-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-right-duotone.svg)
   static const arrowRight = PhosphorDuotoneIconData(
     0xe9b9,
-    PhosphorIconData(0xe9b8, 'duotone'),
+    PhosphorIconData(0xe9b8, 'Duotone'),
   );
 
   /// ![arrow-square-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-square-down-duotone.svg)
   static const arrowSquareDown = PhosphorDuotoneIconData(
     0xe9db,
-    PhosphorIconData(0xe9da, 'duotone'),
+    PhosphorIconData(0xe9da, 'Duotone'),
   );
 
   /// ![arrow-square-down-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-square-down-left-duotone.svg)
   static const arrowSquareDownLeft = PhosphorDuotoneIconData(
     0xe9dd,
-    PhosphorIconData(0xe9dc, 'duotone'),
+    PhosphorIconData(0xe9dc, 'Duotone'),
   );
 
   /// ![arrow-square-down-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-square-down-right-duotone.svg)
   static const arrowSquareDownRight = PhosphorDuotoneIconData(
     0xe9df,
-    PhosphorIconData(0xe9de, 'duotone'),
+    PhosphorIconData(0xe9de, 'Duotone'),
   );
 
   /// ![arrow-square-in-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-square-in-duotone.svg)
   static const arrowSquareIn = PhosphorDuotoneIconData(
     0xe9e1,
-    PhosphorIconData(0xe9e0, 'duotone'),
+    PhosphorIconData(0xe9e0, 'Duotone'),
   );
 
   /// ![arrow-square-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-square-left-duotone.svg)
   static const arrowSquareLeft = PhosphorDuotoneIconData(
     0xe9e3,
-    PhosphorIconData(0xe9e2, 'duotone'),
+    PhosphorIconData(0xe9e2, 'Duotone'),
   );
 
   /// ![arrow-square-out-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-square-out-duotone.svg)
   static const arrowSquareOut = PhosphorDuotoneIconData(
     0xe9e5,
-    PhosphorIconData(0xe9e4, 'duotone'),
+    PhosphorIconData(0xe9e4, 'Duotone'),
   );
 
   /// ![arrow-square-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-square-right-duotone.svg)
   static const arrowSquareRight = PhosphorDuotoneIconData(
     0xe9e7,
-    PhosphorIconData(0xe9e6, 'duotone'),
+    PhosphorIconData(0xe9e6, 'Duotone'),
   );
 
   /// ![arrow-square-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-square-up-duotone.svg)
   static const arrowSquareUp = PhosphorDuotoneIconData(
     0xe9e9,
-    PhosphorIconData(0xe9e8, 'duotone'),
+    PhosphorIconData(0xe9e8, 'Duotone'),
   );
 
   /// ![arrow-square-up-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-square-up-left-duotone.svg)
   static const arrowSquareUpLeft = PhosphorDuotoneIconData(
     0xe9eb,
-    PhosphorIconData(0xe9ea, 'duotone'),
+    PhosphorIconData(0xe9ea, 'Duotone'),
   );
 
   /// ![arrow-square-up-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-square-up-right-duotone.svg)
   static const arrowSquareUpRight = PhosphorDuotoneIconData(
     0xe9ed,
-    PhosphorIconData(0xe9ec, 'duotone'),
+    PhosphorIconData(0xe9ec, 'Duotone'),
   );
 
   /// ![arrow-u-down-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-u-down-left-duotone.svg)
   static const arrowUDownLeft = PhosphorDuotoneIconData(
     0xe9f3,
-    PhosphorIconData(0xe9f2, 'duotone'),
+    PhosphorIconData(0xe9f2, 'Duotone'),
   );
 
   /// ![arrow-u-down-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-u-down-right-duotone.svg)
   static const arrowUDownRight = PhosphorDuotoneIconData(
     0xe9f5,
-    PhosphorIconData(0xe9f4, 'duotone'),
+    PhosphorIconData(0xe9f4, 'Duotone'),
   );
 
   /// ![arrow-u-left-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-u-left-down-duotone.svg)
   static const arrowULeftDown = PhosphorDuotoneIconData(
     0xe9f7,
-    PhosphorIconData(0xe9f6, 'duotone'),
+    PhosphorIconData(0xe9f6, 'Duotone'),
   );
 
   /// ![arrow-u-left-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-u-left-up-duotone.svg)
   static const arrowULeftUp = PhosphorDuotoneIconData(
     0xe9f9,
-    PhosphorIconData(0xe9f8, 'duotone'),
+    PhosphorIconData(0xe9f8, 'Duotone'),
   );
 
   /// ![arrow-u-right-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-u-right-down-duotone.svg)
   static const arrowURightDown = PhosphorDuotoneIconData(
     0xea01,
-    PhosphorIconData(0xea00, 'duotone'),
+    PhosphorIconData(0xea00, 'Duotone'),
   );
 
   /// ![arrow-u-right-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-u-right-up-duotone.svg)
   static const arrowURightUp = PhosphorDuotoneIconData(
     0xea03,
-    PhosphorIconData(0xea02, 'duotone'),
+    PhosphorIconData(0xea02, 'Duotone'),
   );
 
   /// ![arrow-u-up-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-u-up-left-duotone.svg)
   static const arrowUUpLeft = PhosphorDuotoneIconData(
     0xea05,
-    PhosphorIconData(0xea04, 'duotone'),
+    PhosphorIconData(0xea04, 'Duotone'),
   );
 
   /// ![arrow-u-up-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-u-up-right-duotone.svg)
   static const arrowUUpRight = PhosphorDuotoneIconData(
     0xea07,
-    PhosphorIconData(0xea06, 'duotone'),
+    PhosphorIconData(0xea06, 'Duotone'),
   );
 
   /// ![arrow-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-up-duotone.svg)
   static const arrowUp = PhosphorDuotoneIconData(
     0xe9fb,
-    PhosphorIconData(0xe9fa, 'duotone'),
+    PhosphorIconData(0xe9fa, 'Duotone'),
   );
 
   /// ![arrow-up-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-up-left-duotone.svg)
   static const arrowUpLeft = PhosphorDuotoneIconData(
     0xe9fd,
-    PhosphorIconData(0xe9fc, 'duotone'),
+    PhosphorIconData(0xe9fc, 'Duotone'),
   );
 
   /// ![arrow-up-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-up-right-duotone.svg)
   static const arrowUpRight = PhosphorDuotoneIconData(
     0xe9ff,
-    PhosphorIconData(0xe9fe, 'duotone'),
+    PhosphorIconData(0xe9fe, 'Duotone'),
   );
 
   /// ![arrows-clockwise-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrows-clockwise-duotone.svg)
   static const arrowsClockwise = PhosphorDuotoneIconData(
     0xe9bb,
-    PhosphorIconData(0xe9ba, 'duotone'),
+    PhosphorIconData(0xe9ba, 'Duotone'),
   );
 
   /// ![arrows-counter-clockwise-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrows-counter-clockwise-duotone.svg)
   static const arrowsCounterClockwise = PhosphorDuotoneIconData(
     0xe9bd,
-    PhosphorIconData(0xe9bc, 'duotone'),
+    PhosphorIconData(0xe9bc, 'Duotone'),
   );
 
   /// ![arrows-down-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrows-down-up-duotone.svg)
   static const arrowsDownUp = PhosphorDuotoneIconData(
     0xe9bf,
-    PhosphorIconData(0xe9be, 'duotone'),
+    PhosphorIconData(0xe9be, 'Duotone'),
   );
 
   /// ![arrows-horizontal-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrows-horizontal-duotone.svg)
   static const arrowsHorizontal = PhosphorDuotoneIconData(
     0xe9c1,
-    PhosphorIconData(0xe9c0, 'duotone'),
+    PhosphorIconData(0xe9c0, 'Duotone'),
   );
 
   /// ![arrows-in-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrows-in-duotone.svg)
   static const arrowsIn = PhosphorDuotoneIconData(
     0xe9c5,
-    PhosphorIconData(0xe9c4, 'duotone'),
+    PhosphorIconData(0xe9c4, 'Duotone'),
   );
 
   /// ![arrows-in-cardinal-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrows-in-cardinal-duotone.svg)
   static const arrowsInCardinal = PhosphorDuotoneIconData(
     0xe9c3,
-    PhosphorIconData(0xe9c2, 'duotone'),
+    PhosphorIconData(0xe9c2, 'Duotone'),
   );
 
   /// ![arrows-in-line-horizontal-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrows-in-line-horizontal-duotone.svg)
   static const arrowsInLineHorizontal = PhosphorDuotoneIconData(
     0xe9c7,
-    PhosphorIconData(0xe9c6, 'duotone'),
+    PhosphorIconData(0xe9c6, 'Duotone'),
   );
 
   /// ![arrows-in-line-vertical-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrows-in-line-vertical-duotone.svg)
   static const arrowsInLineVertical = PhosphorDuotoneIconData(
     0xe9c9,
-    PhosphorIconData(0xe9c8, 'duotone'),
+    PhosphorIconData(0xe9c8, 'Duotone'),
   );
 
   /// ![arrows-in-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrows-in-simple-duotone.svg)
   static const arrowsInSimple = PhosphorDuotoneIconData(
     0xe9cb,
-    PhosphorIconData(0xe9ca, 'duotone'),
+    PhosphorIconData(0xe9ca, 'Duotone'),
   );
 
   /// ![arrows-left-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrows-left-right-duotone.svg)
   static const arrowsLeftRight = PhosphorDuotoneIconData(
     0xe9cd,
-    PhosphorIconData(0xe9cc, 'duotone'),
+    PhosphorIconData(0xe9cc, 'Duotone'),
   );
 
   /// ![arrows-merge-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrows-merge-duotone.svg)
   static const arrowsMerge = PhosphorDuotoneIconData(
     0xe9cf,
-    PhosphorIconData(0xe9ce, 'duotone'),
+    PhosphorIconData(0xe9ce, 'Duotone'),
   );
 
   /// ![arrows-out-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrows-out-duotone.svg)
   static const arrowsOut = PhosphorDuotoneIconData(
     0xe9d3,
-    PhosphorIconData(0xe9d2, 'duotone'),
+    PhosphorIconData(0xe9d2, 'Duotone'),
   );
 
   /// ![arrows-out-cardinal-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrows-out-cardinal-duotone.svg)
   static const arrowsOutCardinal = PhosphorDuotoneIconData(
     0xe9d1,
-    PhosphorIconData(0xe9d0, 'duotone'),
+    PhosphorIconData(0xe9d0, 'Duotone'),
   );
 
   /// ![arrows-out-line-horizontal-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrows-out-line-horizontal-duotone.svg)
   static const arrowsOutLineHorizontal = PhosphorDuotoneIconData(
     0xe9d5,
-    PhosphorIconData(0xe9d4, 'duotone'),
+    PhosphorIconData(0xe9d4, 'Duotone'),
   );
 
   /// ![arrows-out-line-vertical-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrows-out-line-vertical-duotone.svg)
   static const arrowsOutLineVertical = PhosphorDuotoneIconData(
     0xe9d7,
-    PhosphorIconData(0xe9d6, 'duotone'),
+    PhosphorIconData(0xe9d6, 'Duotone'),
   );
 
   /// ![arrows-out-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrows-out-simple-duotone.svg)
   static const arrowsOutSimple = PhosphorDuotoneIconData(
     0xe9d9,
-    PhosphorIconData(0xe9d8, 'duotone'),
+    PhosphorIconData(0xe9d8, 'Duotone'),
   );
 
   /// ![arrows-split-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrows-split-duotone.svg)
   static const arrowsSplit = PhosphorDuotoneIconData(
     0xe9ef,
-    PhosphorIconData(0xe9ee, 'duotone'),
+    PhosphorIconData(0xe9ee, 'Duotone'),
   );
 
   /// ![arrows-vertical-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrows-vertical-duotone.svg)
   static const arrowsVertical = PhosphorDuotoneIconData(
     0xe9f1,
-    PhosphorIconData(0xe9f0, 'duotone'),
+    PhosphorIconData(0xe9f0, 'Duotone'),
   );
 
   /// ![article-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/article-duotone.svg)
   static const article = PhosphorDuotoneIconData(
     0xea09,
-    PhosphorIconData(0xea08, 'duotone'),
+    PhosphorIconData(0xea08, 'Duotone'),
   );
 
   /// ![article-medium-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/article-medium-duotone.svg)
   static const articleMedium = PhosphorDuotoneIconData(
     0xea0b,
-    PhosphorIconData(0xea0a, 'duotone'),
+    PhosphorIconData(0xea0a, 'Duotone'),
   );
 
   /// ![article-ny-times-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/article-ny-times-duotone.svg)
   static const articleNyTimes = PhosphorDuotoneIconData(
     0xea0d,
-    PhosphorIconData(0xea0c, 'duotone'),
+    PhosphorIconData(0xea0c, 'Duotone'),
   );
 
   /// ![asterisk-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/asterisk-duotone.svg)
   static const asterisk = PhosphorDuotoneIconData(
     0xea0f,
-    PhosphorIconData(0xea0e, 'duotone'),
+    PhosphorIconData(0xea0e, 'Duotone'),
   );
 
   /// ![asterisk-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/asterisk-simple-duotone.svg)
   static const asteriskSimple = PhosphorDuotoneIconData(
     0xea11,
-    PhosphorIconData(0xea10, 'duotone'),
+    PhosphorIconData(0xea10, 'Duotone'),
   );
 
   /// ![at-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/at-duotone.svg)
   static const at = PhosphorDuotoneIconData(
     0xea13,
-    PhosphorIconData(0xea12, 'duotone'),
+    PhosphorIconData(0xea12, 'Duotone'),
   );
 
   /// ![atom-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/atom-duotone.svg)
   static const atom = PhosphorDuotoneIconData(
     0xea15,
-    PhosphorIconData(0xea14, 'duotone'),
+    PhosphorIconData(0xea14, 'Duotone'),
   );
 
   /// ![baby-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/baby-duotone.svg)
   static const baby = PhosphorDuotoneIconData(
     0xea17,
-    PhosphorIconData(0xea16, 'duotone'),
+    PhosphorIconData(0xea16, 'Duotone'),
   );
 
   /// ![backpack-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/backpack-duotone.svg)
   static const backpack = PhosphorDuotoneIconData(
     0xea19,
-    PhosphorIconData(0xea18, 'duotone'),
+    PhosphorIconData(0xea18, 'Duotone'),
   );
 
   /// ![backspace-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/backspace-duotone.svg)
   static const backspace = PhosphorDuotoneIconData(
     0xea1b,
-    PhosphorIconData(0xea1a, 'duotone'),
+    PhosphorIconData(0xea1a, 'Duotone'),
   );
 
   /// ![bag-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bag-duotone.svg)
   static const bag = PhosphorDuotoneIconData(
     0xea1d,
-    PhosphorIconData(0xea1c, 'duotone'),
+    PhosphorIconData(0xea1c, 'Duotone'),
   );
 
   /// ![bag-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bag-simple-duotone.svg)
   static const bagSimple = PhosphorDuotoneIconData(
     0xea1f,
-    PhosphorIconData(0xea1e, 'duotone'),
+    PhosphorIconData(0xea1e, 'Duotone'),
   );
 
   /// ![balloon-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/balloon-duotone.svg)
   static const balloon = PhosphorDuotoneIconData(
     0xea21,
-    PhosphorIconData(0xea20, 'duotone'),
+    PhosphorIconData(0xea20, 'Duotone'),
   );
 
   /// ![bandaids-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bandaids-duotone.svg)
   static const bandaids = PhosphorDuotoneIconData(
     0xea23,
-    PhosphorIconData(0xea22, 'duotone'),
+    PhosphorIconData(0xea22, 'Duotone'),
   );
 
   /// ![bank-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bank-duotone.svg)
   static const bank = PhosphorDuotoneIconData(
     0xea25,
-    PhosphorIconData(0xea24, 'duotone'),
+    PhosphorIconData(0xea24, 'Duotone'),
   );
 
   /// ![barbell-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/barbell-duotone.svg)
   static const barbell = PhosphorDuotoneIconData(
     0xea27,
-    PhosphorIconData(0xea26, 'duotone'),
+    PhosphorIconData(0xea26, 'Duotone'),
   );
 
   /// ![barcode-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/barcode-duotone.svg)
   static const barcode = PhosphorDuotoneIconData(
     0xea29,
-    PhosphorIconData(0xea28, 'duotone'),
+    PhosphorIconData(0xea28, 'Duotone'),
   );
 
   /// ![barricade-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/barricade-duotone.svg)
   static const barricade = PhosphorDuotoneIconData(
     0xea2b,
-    PhosphorIconData(0xea2a, 'duotone'),
+    PhosphorIconData(0xea2a, 'Duotone'),
   );
 
   /// ![baseball-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/baseball-duotone.svg)
   static const baseball = PhosphorDuotoneIconData(
     0xea2f,
-    PhosphorIconData(0xea2e, 'duotone'),
+    PhosphorIconData(0xea2e, 'Duotone'),
   );
 
   /// ![baseball-cap-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/baseball-cap-duotone.svg)
   static const baseballCap = PhosphorDuotoneIconData(
     0xea2d,
-    PhosphorIconData(0xea2c, 'duotone'),
+    PhosphorIconData(0xea2c, 'Duotone'),
   );
 
   /// ![basket-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/basket-duotone.svg)
   static const basket = PhosphorDuotoneIconData(
     0xea33,
-    PhosphorIconData(0xea32, 'duotone'),
+    PhosphorIconData(0xea32, 'Duotone'),
   );
 
   /// ![basketball-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/basketball-duotone.svg)
   static const basketball = PhosphorDuotoneIconData(
     0xea31,
-    PhosphorIconData(0xea30, 'duotone'),
+    PhosphorIconData(0xea30, 'Duotone'),
   );
 
   /// ![bathtub-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bathtub-duotone.svg)
   static const bathtub = PhosphorDuotoneIconData(
     0xea35,
-    PhosphorIconData(0xea34, 'duotone'),
+    PhosphorIconData(0xea34, 'Duotone'),
   );
 
   /// ![battery-charging-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/battery-charging-duotone.svg)
   static const batteryCharging = PhosphorDuotoneIconData(
     0xea37,
-    PhosphorIconData(0xea36, 'duotone'),
+    PhosphorIconData(0xea36, 'Duotone'),
   );
 
   /// ![battery-charging-vertical-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/battery-charging-vertical-duotone.svg)
   static const batteryChargingVertical = PhosphorDuotoneIconData(
     0xea39,
-    PhosphorIconData(0xea38, 'duotone'),
+    PhosphorIconData(0xea38, 'Duotone'),
   );
 
   /// ![battery-empty-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/battery-empty-duotone.svg)
   static const batteryEmpty = PhosphorDuotoneIconData(
     0xea3b,
-    PhosphorIconData(0xea3a, 'duotone'),
+    PhosphorIconData(0xea3a, 'Duotone'),
   );
 
   /// ![battery-full-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/battery-full-duotone.svg)
   static const batteryFull = PhosphorDuotoneIconData(
     0xea3d,
-    PhosphorIconData(0xea3c, 'duotone'),
+    PhosphorIconData(0xea3c, 'Duotone'),
   );
 
   /// ![battery-high-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/battery-high-duotone.svg)
   static const batteryHigh = PhosphorDuotoneIconData(
     0xea3f,
-    PhosphorIconData(0xea3e, 'duotone'),
+    PhosphorIconData(0xea3e, 'Duotone'),
   );
 
   /// ![battery-low-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/battery-low-duotone.svg)
   static const batteryLow = PhosphorDuotoneIconData(
     0xea41,
-    PhosphorIconData(0xea40, 'duotone'),
+    PhosphorIconData(0xea40, 'Duotone'),
   );
 
   /// ![battery-medium-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/battery-medium-duotone.svg)
   static const batteryMedium = PhosphorDuotoneIconData(
     0xea43,
-    PhosphorIconData(0xea42, 'duotone'),
+    PhosphorIconData(0xea42, 'Duotone'),
   );
 
   /// ![battery-plus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/battery-plus-duotone.svg)
   static const batteryPlus = PhosphorDuotoneIconData(
     0xea45,
-    PhosphorIconData(0xea44, 'duotone'),
+    PhosphorIconData(0xea44, 'Duotone'),
   );
 
   /// ![battery-plus-vertical-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/battery-plus-vertical-duotone.svg)
   static const batteryPlusVertical = PhosphorDuotoneIconData(
     0xea47,
-    PhosphorIconData(0xea46, 'duotone'),
+    PhosphorIconData(0xea46, 'Duotone'),
   );
 
   /// ![battery-vertical-empty-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/battery-vertical-empty-duotone.svg)
   static const batteryVerticalEmpty = PhosphorDuotoneIconData(
     0xea49,
-    PhosphorIconData(0xea48, 'duotone'),
+    PhosphorIconData(0xea48, 'Duotone'),
   );
 
   /// ![battery-vertical-full-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/battery-vertical-full-duotone.svg)
   static const batteryVerticalFull = PhosphorDuotoneIconData(
     0xea4b,
-    PhosphorIconData(0xea4a, 'duotone'),
+    PhosphorIconData(0xea4a, 'Duotone'),
   );
 
   /// ![battery-vertical-high-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/battery-vertical-high-duotone.svg)
   static const batteryVerticalHigh = PhosphorDuotoneIconData(
     0xea4d,
-    PhosphorIconData(0xea4c, 'duotone'),
+    PhosphorIconData(0xea4c, 'Duotone'),
   );
 
   /// ![battery-vertical-low-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/battery-vertical-low-duotone.svg)
   static const batteryVerticalLow = PhosphorDuotoneIconData(
     0xea4f,
-    PhosphorIconData(0xea4e, 'duotone'),
+    PhosphorIconData(0xea4e, 'Duotone'),
   );
 
   /// ![battery-vertical-medium-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/battery-vertical-medium-duotone.svg)
   static const batteryVerticalMedium = PhosphorDuotoneIconData(
     0xea51,
-    PhosphorIconData(0xea50, 'duotone'),
+    PhosphorIconData(0xea50, 'Duotone'),
   );
 
   /// ![battery-warning-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/battery-warning-duotone.svg)
   static const batteryWarning = PhosphorDuotoneIconData(
     0xea53,
-    PhosphorIconData(0xea52, 'duotone'),
+    PhosphorIconData(0xea52, 'Duotone'),
   );
 
   /// ![battery-warning-vertical-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/battery-warning-vertical-duotone.svg)
   static const batteryWarningVertical = PhosphorDuotoneIconData(
     0xea55,
-    PhosphorIconData(0xea54, 'duotone'),
+    PhosphorIconData(0xea54, 'Duotone'),
   );
 
   /// ![bed-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bed-duotone.svg)
   static const bed = PhosphorDuotoneIconData(
     0xea57,
-    PhosphorIconData(0xea56, 'duotone'),
+    PhosphorIconData(0xea56, 'Duotone'),
   );
 
   /// ![beer-bottle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/beer-bottle-duotone.svg)
   static const beerBottle = PhosphorDuotoneIconData(
     0xea59,
-    PhosphorIconData(0xea58, 'duotone'),
+    PhosphorIconData(0xea58, 'Duotone'),
   );
 
   /// ![beer-stein-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/beer-stein-duotone.svg)
   static const beerStein = PhosphorDuotoneIconData(
     0xea5b,
-    PhosphorIconData(0xea5a, 'duotone'),
+    PhosphorIconData(0xea5a, 'Duotone'),
   );
 
   /// ![behance-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/behance-logo-duotone.svg)
   static const behanceLogo = PhosphorDuotoneIconData(
     0xea5d,
-    PhosphorIconData(0xea5c, 'duotone'),
+    PhosphorIconData(0xea5c, 'Duotone'),
   );
 
   /// ![bell-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bell-duotone.svg)
   static const bell = PhosphorDuotoneIconData(
     0xea5f,
-    PhosphorIconData(0xea5e, 'duotone'),
+    PhosphorIconData(0xea5e, 'Duotone'),
   );
 
   /// ![bell-ringing-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bell-ringing-duotone.svg)
   static const bellRinging = PhosphorDuotoneIconData(
     0xea61,
-    PhosphorIconData(0xea60, 'duotone'),
+    PhosphorIconData(0xea60, 'Duotone'),
   );
 
   /// ![bell-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bell-simple-duotone.svg)
   static const bellSimple = PhosphorDuotoneIconData(
     0xea63,
-    PhosphorIconData(0xea62, 'duotone'),
+    PhosphorIconData(0xea62, 'Duotone'),
   );
 
   /// ![bell-simple-ringing-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bell-simple-ringing-duotone.svg)
   static const bellSimpleRinging = PhosphorDuotoneIconData(
     0xea65,
-    PhosphorIconData(0xea64, 'duotone'),
+    PhosphorIconData(0xea64, 'Duotone'),
   );
 
   /// ![bell-simple-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bell-simple-slash-duotone.svg)
   static const bellSimpleSlash = PhosphorDuotoneIconData(
     0xea67,
-    PhosphorIconData(0xea66, 'duotone'),
+    PhosphorIconData(0xea66, 'Duotone'),
   );
 
   /// ![bell-simple-z-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bell-simple-z-duotone.svg)
   static const bellSimpleZ = PhosphorDuotoneIconData(
     0xea69,
-    PhosphorIconData(0xea68, 'duotone'),
+    PhosphorIconData(0xea68, 'Duotone'),
   );
 
   /// ![bell-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bell-slash-duotone.svg)
   static const bellSlash = PhosphorDuotoneIconData(
     0xea6b,
-    PhosphorIconData(0xea6a, 'duotone'),
+    PhosphorIconData(0xea6a, 'Duotone'),
   );
 
   /// ![bell-z-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bell-z-duotone.svg)
   static const bellZ = PhosphorDuotoneIconData(
     0xea6d,
-    PhosphorIconData(0xea6c, 'duotone'),
+    PhosphorIconData(0xea6c, 'Duotone'),
   );
 
   /// ![bezier-curve-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bezier-curve-duotone.svg)
   static const bezierCurve = PhosphorDuotoneIconData(
     0xea6f,
-    PhosphorIconData(0xea6e, 'duotone'),
+    PhosphorIconData(0xea6e, 'Duotone'),
   );
 
   /// ![bicycle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bicycle-duotone.svg)
   static const bicycle = PhosphorDuotoneIconData(
     0xea71,
-    PhosphorIconData(0xea70, 'duotone'),
+    PhosphorIconData(0xea70, 'Duotone'),
   );
 
   /// ![binoculars-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/binoculars-duotone.svg)
   static const binoculars = PhosphorDuotoneIconData(
     0xea73,
-    PhosphorIconData(0xea72, 'duotone'),
+    PhosphorIconData(0xea72, 'Duotone'),
   );
 
   /// ![bird-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bird-duotone.svg)
   static const bird = PhosphorDuotoneIconData(
     0xea75,
-    PhosphorIconData(0xea74, 'duotone'),
+    PhosphorIconData(0xea74, 'Duotone'),
   );
 
   /// ![bluetooth-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bluetooth-duotone.svg)
   static const bluetooth = PhosphorDuotoneIconData(
     0xea79,
-    PhosphorIconData(0xea78, 'duotone'),
+    PhosphorIconData(0xea78, 'Duotone'),
   );
 
   /// ![bluetooth-connected-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bluetooth-connected-duotone.svg)
   static const bluetoothConnected = PhosphorDuotoneIconData(
     0xea77,
-    PhosphorIconData(0xea76, 'duotone'),
+    PhosphorIconData(0xea76, 'Duotone'),
   );
 
   /// ![bluetooth-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bluetooth-slash-duotone.svg)
   static const bluetoothSlash = PhosphorDuotoneIconData(
     0xea7b,
-    PhosphorIconData(0xea7a, 'duotone'),
+    PhosphorIconData(0xea7a, 'Duotone'),
   );
 
   /// ![bluetooth-x-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bluetooth-x-duotone.svg)
   static const bluetoothX = PhosphorDuotoneIconData(
     0xea7d,
-    PhosphorIconData(0xea7c, 'duotone'),
+    PhosphorIconData(0xea7c, 'Duotone'),
   );
 
   /// ![boat-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/boat-duotone.svg)
   static const boat = PhosphorDuotoneIconData(
     0xea7f,
-    PhosphorIconData(0xea7e, 'duotone'),
+    PhosphorIconData(0xea7e, 'Duotone'),
   );
 
   /// ![bone-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bone-duotone.svg)
   static const bone = PhosphorDuotoneIconData(
     0xea81,
-    PhosphorIconData(0xea80, 'duotone'),
+    PhosphorIconData(0xea80, 'Duotone'),
   );
 
   /// ![book-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/book-duotone.svg)
   static const book = PhosphorDuotoneIconData(
     0xea85,
-    PhosphorIconData(0xea84, 'duotone'),
+    PhosphorIconData(0xea84, 'Duotone'),
   );
 
   /// ![book-bookmark-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/book-bookmark-duotone.svg)
   static const bookBookmark = PhosphorDuotoneIconData(
     0xea83,
-    PhosphorIconData(0xea82, 'duotone'),
+    PhosphorIconData(0xea82, 'Duotone'),
   );
 
   /// ![book-open-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/book-open-duotone.svg)
   static const bookOpen = PhosphorDuotoneIconData(
     0xea8f,
-    PhosphorIconData(0xea8e, 'duotone'),
+    PhosphorIconData(0xea8e, 'Duotone'),
   );
 
   /// ![book-open-text-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/book-open-text-duotone.svg)
   static const bookOpenText = PhosphorDuotoneIconData(
     0xea91,
-    PhosphorIconData(0xea90, 'duotone'),
+    PhosphorIconData(0xea90, 'Duotone'),
   );
 
   /// ![bookmark-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bookmark-duotone.svg)
   static const bookmark = PhosphorDuotoneIconData(
     0xea87,
-    PhosphorIconData(0xea86, 'duotone'),
+    PhosphorIconData(0xea86, 'Duotone'),
   );
 
   /// ![bookmark-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bookmark-simple-duotone.svg)
   static const bookmarkSimple = PhosphorDuotoneIconData(
     0xea8b,
-    PhosphorIconData(0xea8a, 'duotone'),
+    PhosphorIconData(0xea8a, 'Duotone'),
   );
 
   /// ![bookmarks-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bookmarks-duotone.svg)
   static const bookmarks = PhosphorDuotoneIconData(
     0xea89,
-    PhosphorIconData(0xea88, 'duotone'),
+    PhosphorIconData(0xea88, 'Duotone'),
   );
 
   /// ![bookmarks-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bookmarks-simple-duotone.svg)
   static const bookmarksSimple = PhosphorDuotoneIconData(
     0xea8d,
-    PhosphorIconData(0xea8c, 'duotone'),
+    PhosphorIconData(0xea8c, 'Duotone'),
   );
 
   /// ![books-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/books-duotone.svg)
   static const books = PhosphorDuotoneIconData(
     0xea93,
-    PhosphorIconData(0xea92, 'duotone'),
+    PhosphorIconData(0xea92, 'Duotone'),
   );
 
   /// ![boot-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/boot-duotone.svg)
   static const boot = PhosphorDuotoneIconData(
     0xea95,
-    PhosphorIconData(0xea94, 'duotone'),
+    PhosphorIconData(0xea94, 'Duotone'),
   );
 
   /// ![bounding-box-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bounding-box-duotone.svg)
   static const boundingBox = PhosphorDuotoneIconData(
     0xea97,
-    PhosphorIconData(0xea96, 'duotone'),
+    PhosphorIconData(0xea96, 'Duotone'),
   );
 
   /// ![bowl-food-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bowl-food-duotone.svg)
   static const bowlFood = PhosphorDuotoneIconData(
     0xea99,
-    PhosphorIconData(0xea98, 'duotone'),
+    PhosphorIconData(0xea98, 'Duotone'),
   );
 
   /// ![brackets-angle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/brackets-angle-duotone.svg)
   static const bracketsAngle = PhosphorDuotoneIconData(
     0xea9b,
-    PhosphorIconData(0xea9a, 'duotone'),
+    PhosphorIconData(0xea9a, 'Duotone'),
   );
 
   /// ![brackets-curly-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/brackets-curly-duotone.svg)
   static const bracketsCurly = PhosphorDuotoneIconData(
     0xea9d,
-    PhosphorIconData(0xea9c, 'duotone'),
+    PhosphorIconData(0xea9c, 'Duotone'),
   );
 
   /// ![brackets-round-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/brackets-round-duotone.svg)
   static const bracketsRound = PhosphorDuotoneIconData(
     0xea9f,
-    PhosphorIconData(0xea9e, 'duotone'),
+    PhosphorIconData(0xea9e, 'Duotone'),
   );
 
   /// ![brackets-square-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/brackets-square-duotone.svg)
   static const bracketsSquare = PhosphorDuotoneIconData(
     0xeaa1,
-    PhosphorIconData(0xeaa0, 'duotone'),
+    PhosphorIconData(0xeaa0, 'Duotone'),
   );
 
   /// ![brain-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/brain-duotone.svg)
   static const brain = PhosphorDuotoneIconData(
     0xeaa3,
-    PhosphorIconData(0xeaa2, 'duotone'),
+    PhosphorIconData(0xeaa2, 'Duotone'),
   );
 
   /// ![brandy-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/brandy-duotone.svg)
   static const brandy = PhosphorDuotoneIconData(
     0xeaa5,
-    PhosphorIconData(0xeaa4, 'duotone'),
+    PhosphorIconData(0xeaa4, 'Duotone'),
   );
 
   /// ![bridge-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bridge-duotone.svg)
   static const bridge = PhosphorDuotoneIconData(
     0xeaa7,
-    PhosphorIconData(0xeaa6, 'duotone'),
+    PhosphorIconData(0xeaa6, 'Duotone'),
   );
 
   /// ![briefcase-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/briefcase-duotone.svg)
   static const briefcase = PhosphorDuotoneIconData(
     0xeaa9,
-    PhosphorIconData(0xeaa8, 'duotone'),
+    PhosphorIconData(0xeaa8, 'Duotone'),
   );
 
   /// ![briefcase-metal-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/briefcase-metal-duotone.svg)
   static const briefcaseMetal = PhosphorDuotoneIconData(
     0xeaab,
-    PhosphorIconData(0xeaaa, 'duotone'),
+    PhosphorIconData(0xeaaa, 'Duotone'),
   );
 
   /// ![broadcast-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/broadcast-duotone.svg)
   static const broadcast = PhosphorDuotoneIconData(
     0xeaad,
-    PhosphorIconData(0xeaac, 'duotone'),
+    PhosphorIconData(0xeaac, 'Duotone'),
   );
 
   /// ![broom-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/broom-duotone.svg)
   static const broom = PhosphorDuotoneIconData(
     0xeaaf,
-    PhosphorIconData(0xeaae, 'duotone'),
+    PhosphorIconData(0xeaae, 'Duotone'),
   );
 
   /// ![browser-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/browser-duotone.svg)
   static const browser = PhosphorDuotoneIconData(
     0xeab1,
-    PhosphorIconData(0xeab0, 'duotone'),
+    PhosphorIconData(0xeab0, 'Duotone'),
   );
 
   /// ![browsers-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/browsers-duotone.svg)
   static const browsers = PhosphorDuotoneIconData(
     0xeab3,
-    PhosphorIconData(0xeab2, 'duotone'),
+    PhosphorIconData(0xeab2, 'Duotone'),
   );
 
   /// ![bug-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bug-duotone.svg)
   static const bug = PhosphorDuotoneIconData(
     0xeab9,
-    PhosphorIconData(0xeab8, 'duotone'),
+    PhosphorIconData(0xeab8, 'Duotone'),
   );
 
   /// ![bug-beetle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bug-beetle-duotone.svg)
   static const bugBeetle = PhosphorDuotoneIconData(
     0xeab5,
-    PhosphorIconData(0xeab4, 'duotone'),
+    PhosphorIconData(0xeab4, 'Duotone'),
   );
 
   /// ![bug-droid-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bug-droid-duotone.svg)
   static const bugDroid = PhosphorDuotoneIconData(
     0xeab7,
-    PhosphorIconData(0xeab6, 'duotone'),
+    PhosphorIconData(0xeab6, 'Duotone'),
   );
 
   /// ![buildings-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/buildings-duotone.svg)
   static const buildings = PhosphorDuotoneIconData(
     0xeabb,
-    PhosphorIconData(0xeaba, 'duotone'),
+    PhosphorIconData(0xeaba, 'Duotone'),
   );
 
   /// ![bus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bus-duotone.svg)
   static const bus = PhosphorDuotoneIconData(
     0xeabd,
-    PhosphorIconData(0xeabc, 'duotone'),
+    PhosphorIconData(0xeabc, 'Duotone'),
   );
 
   /// ![butterfly-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/butterfly-duotone.svg)
   static const butterfly = PhosphorDuotoneIconData(
     0xeabf,
-    PhosphorIconData(0xeabe, 'duotone'),
+    PhosphorIconData(0xeabe, 'Duotone'),
   );
 
   /// ![cactus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cactus-duotone.svg)
   static const cactus = PhosphorDuotoneIconData(
     0xeac1,
-    PhosphorIconData(0xeac0, 'duotone'),
+    PhosphorIconData(0xeac0, 'Duotone'),
   );
 
   /// ![cake-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cake-duotone.svg)
   static const cake = PhosphorDuotoneIconData(
     0xeac3,
-    PhosphorIconData(0xeac2, 'duotone'),
+    PhosphorIconData(0xeac2, 'Duotone'),
   );
 
   /// ![calculator-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/calculator-duotone.svg)
   static const calculator = PhosphorDuotoneIconData(
     0xeac5,
-    PhosphorIconData(0xeac4, 'duotone'),
+    PhosphorIconData(0xeac4, 'Duotone'),
   );
 
   /// ![calendar-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/calendar-duotone.svg)
   static const calendar = PhosphorDuotoneIconData(
     0xeacb,
-    PhosphorIconData(0xeaca, 'duotone'),
+    PhosphorIconData(0xeaca, 'Duotone'),
   );
 
   /// ![calendar-blank-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/calendar-blank-duotone.svg)
   static const calendarBlank = PhosphorDuotoneIconData(
     0xeac7,
-    PhosphorIconData(0xeac6, 'duotone'),
+    PhosphorIconData(0xeac6, 'Duotone'),
   );
 
   /// ![calendar-check-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/calendar-check-duotone.svg)
   static const calendarCheck = PhosphorDuotoneIconData(
     0xeac9,
-    PhosphorIconData(0xeac8, 'duotone'),
+    PhosphorIconData(0xeac8, 'Duotone'),
   );
 
   /// ![calendar-plus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/calendar-plus-duotone.svg)
   static const calendarPlus = PhosphorDuotoneIconData(
     0xeacd,
-    PhosphorIconData(0xeacc, 'duotone'),
+    PhosphorIconData(0xeacc, 'Duotone'),
   );
 
   /// ![calendar-x-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/calendar-x-duotone.svg)
   static const calendarX = PhosphorDuotoneIconData(
     0xeacf,
-    PhosphorIconData(0xeace, 'duotone'),
+    PhosphorIconData(0xeace, 'Duotone'),
   );
 
   /// ![call-bell-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/call-bell-duotone.svg)
   static const callBell = PhosphorDuotoneIconData(
     0xead1,
-    PhosphorIconData(0xead0, 'duotone'),
+    PhosphorIconData(0xead0, 'Duotone'),
   );
 
   /// ![camera-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/camera-duotone.svg)
   static const camera = PhosphorDuotoneIconData(
     0xead3,
-    PhosphorIconData(0xead2, 'duotone'),
+    PhosphorIconData(0xead2, 'Duotone'),
   );
 
   /// ![camera-plus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/camera-plus-duotone.svg)
   static const cameraPlus = PhosphorDuotoneIconData(
     0xead5,
-    PhosphorIconData(0xead4, 'duotone'),
+    PhosphorIconData(0xead4, 'Duotone'),
   );
 
   /// ![camera-rotate-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/camera-rotate-duotone.svg)
   static const cameraRotate = PhosphorDuotoneIconData(
     0xead7,
-    PhosphorIconData(0xead6, 'duotone'),
+    PhosphorIconData(0xead6, 'Duotone'),
   );
 
   /// ![camera-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/camera-slash-duotone.svg)
   static const cameraSlash = PhosphorDuotoneIconData(
     0xead9,
-    PhosphorIconData(0xead8, 'duotone'),
+    PhosphorIconData(0xead8, 'Duotone'),
   );
 
   /// ![campfire-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/campfire-duotone.svg)
   static const campfire = PhosphorDuotoneIconData(
     0xeadb,
-    PhosphorIconData(0xeada, 'duotone'),
+    PhosphorIconData(0xeada, 'Duotone'),
   );
 
   /// ![car-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/car-duotone.svg)
   static const car = PhosphorDuotoneIconData(
     0xeae1,
-    PhosphorIconData(0xeae0, 'duotone'),
+    PhosphorIconData(0xeae0, 'Duotone'),
   );
 
   /// ![car-profile-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/car-profile-duotone.svg)
   static const carProfile = PhosphorDuotoneIconData(
     0xeb07,
-    PhosphorIconData(0xeb06, 'duotone'),
+    PhosphorIconData(0xeb06, 'Duotone'),
   );
 
   /// ![car-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/car-simple-duotone.svg)
   static const carSimple = PhosphorDuotoneIconData(
     0xeb0b,
-    PhosphorIconData(0xeb0a, 'duotone'),
+    PhosphorIconData(0xeb0a, 'Duotone'),
   );
 
   /// ![cardholder-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cardholder-duotone.svg)
   static const cardholder = PhosphorDuotoneIconData(
     0xeadd,
-    PhosphorIconData(0xeadc, 'duotone'),
+    PhosphorIconData(0xeadc, 'Duotone'),
   );
 
   /// ![cards-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cards-duotone.svg)
   static const cards = PhosphorDuotoneIconData(
     0xeadf,
-    PhosphorIconData(0xeade, 'duotone'),
+    PhosphorIconData(0xeade, 'Duotone'),
   );
 
   /// ![caret-circle-double-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/caret-circle-double-down-duotone.svg)
   static const caretCircleDoubleDown = PhosphorDuotoneIconData(
     0xeae3,
-    PhosphorIconData(0xeae2, 'duotone'),
+    PhosphorIconData(0xeae2, 'Duotone'),
   );
 
   /// ![caret-circle-double-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/caret-circle-double-left-duotone.svg)
   static const caretCircleDoubleLeft = PhosphorDuotoneIconData(
     0xeae5,
-    PhosphorIconData(0xeae4, 'duotone'),
+    PhosphorIconData(0xeae4, 'Duotone'),
   );
 
   /// ![caret-circle-double-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/caret-circle-double-right-duotone.svg)
   static const caretCircleDoubleRight = PhosphorDuotoneIconData(
     0xeae7,
-    PhosphorIconData(0xeae6, 'duotone'),
+    PhosphorIconData(0xeae6, 'Duotone'),
   );
 
   /// ![caret-circle-double-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/caret-circle-double-up-duotone.svg)
   static const caretCircleDoubleUp = PhosphorDuotoneIconData(
     0xeae9,
-    PhosphorIconData(0xeae8, 'duotone'),
+    PhosphorIconData(0xeae8, 'Duotone'),
   );
 
   /// ![caret-circle-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/caret-circle-down-duotone.svg)
   static const caretCircleDown = PhosphorDuotoneIconData(
     0xeaeb,
-    PhosphorIconData(0xeaea, 'duotone'),
+    PhosphorIconData(0xeaea, 'Duotone'),
   );
 
   /// ![caret-circle-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/caret-circle-left-duotone.svg)
   static const caretCircleLeft = PhosphorDuotoneIconData(
     0xeaed,
-    PhosphorIconData(0xeaec, 'duotone'),
+    PhosphorIconData(0xeaec, 'Duotone'),
   );
 
   /// ![caret-circle-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/caret-circle-right-duotone.svg)
   static const caretCircleRight = PhosphorDuotoneIconData(
     0xeaef,
-    PhosphorIconData(0xeaee, 'duotone'),
+    PhosphorIconData(0xeaee, 'Duotone'),
   );
 
   /// ![caret-circle-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/caret-circle-up-duotone.svg)
   static const caretCircleUp = PhosphorDuotoneIconData(
     0xeaf3,
-    PhosphorIconData(0xeaf2, 'duotone'),
+    PhosphorIconData(0xeaf2, 'Duotone'),
   );
 
   /// ![caret-circle-up-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/caret-circle-up-down-duotone.svg)
   static const caretCircleUpDown = PhosphorDuotoneIconData(
     0xeaf1,
-    PhosphorIconData(0xeaf0, 'duotone'),
+    PhosphorIconData(0xeaf0, 'Duotone'),
   );
 
   /// ![caret-double-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/caret-double-down-duotone.svg)
   static const caretDoubleDown = PhosphorDuotoneIconData(
     0xeaf5,
-    PhosphorIconData(0xeaf4, 'duotone'),
+    PhosphorIconData(0xeaf4, 'Duotone'),
   );
 
   /// ![caret-double-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/caret-double-left-duotone.svg)
   static const caretDoubleLeft = PhosphorDuotoneIconData(
     0xeaf7,
-    PhosphorIconData(0xeaf6, 'duotone'),
+    PhosphorIconData(0xeaf6, 'Duotone'),
   );
 
   /// ![caret-double-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/caret-double-right-duotone.svg)
   static const caretDoubleRight = PhosphorDuotoneIconData(
     0xeaf9,
-    PhosphorIconData(0xeaf8, 'duotone'),
+    PhosphorIconData(0xeaf8, 'Duotone'),
   );
 
   /// ![caret-double-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/caret-double-up-duotone.svg)
   static const caretDoubleUp = PhosphorDuotoneIconData(
     0xeafb,
-    PhosphorIconData(0xeafa, 'duotone'),
+    PhosphorIconData(0xeafa, 'Duotone'),
   );
 
   /// ![caret-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/caret-down-duotone.svg)
   static const caretDown = PhosphorDuotoneIconData(
     0xeafd,
-    PhosphorIconData(0xeafc, 'duotone'),
+    PhosphorIconData(0xeafc, 'Duotone'),
   );
 
   /// ![caret-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/caret-left-duotone.svg)
   static const caretLeft = PhosphorDuotoneIconData(
     0xeaff,
-    PhosphorIconData(0xeafe, 'duotone'),
+    PhosphorIconData(0xeafe, 'Duotone'),
   );
 
   /// ![caret-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/caret-right-duotone.svg)
   static const caretRight = PhosphorDuotoneIconData(
     0xeb01,
-    PhosphorIconData(0xeb00, 'duotone'),
+    PhosphorIconData(0xeb00, 'Duotone'),
   );
 
   /// ![caret-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/caret-up-duotone.svg)
   static const caretUp = PhosphorDuotoneIconData(
     0xeb05,
-    PhosphorIconData(0xeb04, 'duotone'),
+    PhosphorIconData(0xeb04, 'Duotone'),
   );
 
   /// ![caret-up-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/caret-up-down-duotone.svg)
   static const caretUpDown = PhosphorDuotoneIconData(
     0xeb03,
-    PhosphorIconData(0xeb02, 'duotone'),
+    PhosphorIconData(0xeb02, 'Duotone'),
   );
 
   /// ![carrot-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/carrot-duotone.svg)
   static const carrot = PhosphorDuotoneIconData(
     0xeb09,
-    PhosphorIconData(0xeb08, 'duotone'),
+    PhosphorIconData(0xeb08, 'Duotone'),
   );
 
   /// ![cassette-tape-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cassette-tape-duotone.svg)
   static const cassetteTape = PhosphorDuotoneIconData(
     0xeb0d,
-    PhosphorIconData(0xeb0c, 'duotone'),
+    PhosphorIconData(0xeb0c, 'Duotone'),
   );
 
   /// ![castle-turret-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/castle-turret-duotone.svg)
   static const castleTurret = PhosphorDuotoneIconData(
     0xeb0f,
-    PhosphorIconData(0xeb0e, 'duotone'),
+    PhosphorIconData(0xeb0e, 'Duotone'),
   );
 
   /// ![cat-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cat-duotone.svg)
   static const cat = PhosphorDuotoneIconData(
     0xeb11,
-    PhosphorIconData(0xeb10, 'duotone'),
+    PhosphorIconData(0xeb10, 'Duotone'),
   );
 
   /// ![cell-signal-full-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cell-signal-full-duotone.svg)
   static const cellSignalFull = PhosphorDuotoneIconData(
     0xeb13,
-    PhosphorIconData(0xeb12, 'duotone'),
+    PhosphorIconData(0xeb12, 'Duotone'),
   );
 
   /// ![cell-signal-high-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cell-signal-high-duotone.svg)
   static const cellSignalHigh = PhosphorDuotoneIconData(
     0xeb15,
-    PhosphorIconData(0xeb14, 'duotone'),
+    PhosphorIconData(0xeb14, 'Duotone'),
   );
 
   /// ![cell-signal-low-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cell-signal-low-duotone.svg)
   static const cellSignalLow = PhosphorDuotoneIconData(
     0xeb17,
-    PhosphorIconData(0xeb16, 'duotone'),
+    PhosphorIconData(0xeb16, 'Duotone'),
   );
 
   /// ![cell-signal-medium-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cell-signal-medium-duotone.svg)
   static const cellSignalMedium = PhosphorDuotoneIconData(
     0xeb19,
-    PhosphorIconData(0xeb18, 'duotone'),
+    PhosphorIconData(0xeb18, 'Duotone'),
   );
 
   /// ![cell-signal-none-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cell-signal-none-duotone.svg)
@@ -1626,5797 +1626,5797 @@ class PhosphorIconsDuotone {
   /// ![cell-signal-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cell-signal-slash-duotone.svg)
   static const cellSignalSlash = PhosphorDuotoneIconData(
     0xeb1c,
-    PhosphorIconData(0xeb1b, 'duotone'),
+    PhosphorIconData(0xeb1b, 'Duotone'),
   );
 
   /// ![cell-signal-x-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cell-signal-x-duotone.svg)
   static const cellSignalX = PhosphorDuotoneIconData(
     0xeb1e,
-    PhosphorIconData(0xeb1d, 'duotone'),
+    PhosphorIconData(0xeb1d, 'Duotone'),
   );
 
   /// ![certificate-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/certificate-duotone.svg)
   static const certificate = PhosphorDuotoneIconData(
     0xeb20,
-    PhosphorIconData(0xeb1f, 'duotone'),
+    PhosphorIconData(0xeb1f, 'Duotone'),
   );
 
   /// ![chair-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chair-duotone.svg)
   static const chair = PhosphorDuotoneIconData(
     0xeb22,
-    PhosphorIconData(0xeb21, 'duotone'),
+    PhosphorIconData(0xeb21, 'Duotone'),
   );
 
   /// ![chalkboard-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chalkboard-duotone.svg)
   static const chalkboard = PhosphorDuotoneIconData(
     0xeb24,
-    PhosphorIconData(0xeb23, 'duotone'),
+    PhosphorIconData(0xeb23, 'Duotone'),
   );
 
   /// ![chalkboard-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chalkboard-simple-duotone.svg)
   static const chalkboardSimple = PhosphorDuotoneIconData(
     0xeb26,
-    PhosphorIconData(0xeb25, 'duotone'),
+    PhosphorIconData(0xeb25, 'Duotone'),
   );
 
   /// ![chalkboard-teacher-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chalkboard-teacher-duotone.svg)
   static const chalkboardTeacher = PhosphorDuotoneIconData(
     0xeb28,
-    PhosphorIconData(0xeb27, 'duotone'),
+    PhosphorIconData(0xeb27, 'Duotone'),
   );
 
   /// ![champagne-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/champagne-duotone.svg)
   static const champagne = PhosphorDuotoneIconData(
     0xeb2a,
-    PhosphorIconData(0xeb29, 'duotone'),
+    PhosphorIconData(0xeb29, 'Duotone'),
   );
 
   /// ![charging-station-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/charging-station-duotone.svg)
   static const chargingStation = PhosphorDuotoneIconData(
     0xeb2c,
-    PhosphorIconData(0xeb2b, 'duotone'),
+    PhosphorIconData(0xeb2b, 'Duotone'),
   );
 
   /// ![chart-bar-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chart-bar-duotone.svg)
   static const chartBar = PhosphorDuotoneIconData(
     0xeb2e,
-    PhosphorIconData(0xeb2d, 'duotone'),
+    PhosphorIconData(0xeb2d, 'Duotone'),
   );
 
   /// ![chart-bar-horizontal-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chart-bar-horizontal-duotone.svg)
   static const chartBarHorizontal = PhosphorDuotoneIconData(
     0xeb30,
-    PhosphorIconData(0xeb2f, 'duotone'),
+    PhosphorIconData(0xeb2f, 'Duotone'),
   );
 
   /// ![chart-donut-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chart-donut-duotone.svg)
   static const chartDonut = PhosphorDuotoneIconData(
     0xeb32,
-    PhosphorIconData(0xeb31, 'duotone'),
+    PhosphorIconData(0xeb31, 'Duotone'),
   );
 
   /// ![chart-line-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chart-line-duotone.svg)
   static const chartLine = PhosphorDuotoneIconData(
     0xeb36,
-    PhosphorIconData(0xeb35, 'duotone'),
+    PhosphorIconData(0xeb35, 'Duotone'),
   );
 
   /// ![chart-line-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chart-line-down-duotone.svg)
   static const chartLineDown = PhosphorDuotoneIconData(
     0xeb34,
-    PhosphorIconData(0xeb33, 'duotone'),
+    PhosphorIconData(0xeb33, 'Duotone'),
   );
 
   /// ![chart-line-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chart-line-up-duotone.svg)
   static const chartLineUp = PhosphorDuotoneIconData(
     0xeb38,
-    PhosphorIconData(0xeb37, 'duotone'),
+    PhosphorIconData(0xeb37, 'Duotone'),
   );
 
   /// ![chart-pie-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chart-pie-duotone.svg)
   static const chartPie = PhosphorDuotoneIconData(
     0xeb3a,
-    PhosphorIconData(0xeb39, 'duotone'),
+    PhosphorIconData(0xeb39, 'Duotone'),
   );
 
   /// ![chart-pie-slice-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chart-pie-slice-duotone.svg)
   static const chartPieSlice = PhosphorDuotoneIconData(
     0xeb3c,
-    PhosphorIconData(0xeb3b, 'duotone'),
+    PhosphorIconData(0xeb3b, 'Duotone'),
   );
 
   /// ![chart-polar-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chart-polar-duotone.svg)
   static const chartPolar = PhosphorDuotoneIconData(
     0xeb3e,
-    PhosphorIconData(0xeb3d, 'duotone'),
+    PhosphorIconData(0xeb3d, 'Duotone'),
   );
 
   /// ![chart-scatter-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chart-scatter-duotone.svg)
   static const chartScatter = PhosphorDuotoneIconData(
     0xeb40,
-    PhosphorIconData(0xeb3f, 'duotone'),
+    PhosphorIconData(0xeb3f, 'Duotone'),
   );
 
   /// ![chat-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chat-duotone.svg)
   static const chat = PhosphorDuotoneIconData(
     0xeb50,
-    PhosphorIconData(0xeb4f, 'duotone'),
+    PhosphorIconData(0xeb4f, 'Duotone'),
   );
 
   /// ![chat-centered-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chat-centered-duotone.svg)
   static const chatCentered = PhosphorDuotoneIconData(
     0xeb44,
-    PhosphorIconData(0xeb43, 'duotone'),
+    PhosphorIconData(0xeb43, 'Duotone'),
   );
 
   /// ![chat-centered-dots-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chat-centered-dots-duotone.svg)
   static const chatCenteredDots = PhosphorDuotoneIconData(
     0xeb42,
-    PhosphorIconData(0xeb41, 'duotone'),
+    PhosphorIconData(0xeb41, 'Duotone'),
   );
 
   /// ![chat-centered-text-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chat-centered-text-duotone.svg)
   static const chatCenteredText = PhosphorDuotoneIconData(
     0xeb46,
-    PhosphorIconData(0xeb45, 'duotone'),
+    PhosphorIconData(0xeb45, 'Duotone'),
   );
 
   /// ![chat-circle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chat-circle-duotone.svg)
   static const chatCircle = PhosphorDuotoneIconData(
     0xeb4a,
-    PhosphorIconData(0xeb49, 'duotone'),
+    PhosphorIconData(0xeb49, 'Duotone'),
   );
 
   /// ![chat-circle-dots-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chat-circle-dots-duotone.svg)
   static const chatCircleDots = PhosphorDuotoneIconData(
     0xeb48,
-    PhosphorIconData(0xeb47, 'duotone'),
+    PhosphorIconData(0xeb47, 'Duotone'),
   );
 
   /// ![chat-circle-text-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chat-circle-text-duotone.svg)
   static const chatCircleText = PhosphorDuotoneIconData(
     0xeb4c,
-    PhosphorIconData(0xeb4b, 'duotone'),
+    PhosphorIconData(0xeb4b, 'Duotone'),
   );
 
   /// ![chat-dots-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chat-dots-duotone.svg)
   static const chatDots = PhosphorDuotoneIconData(
     0xeb4e,
-    PhosphorIconData(0xeb4d, 'duotone'),
+    PhosphorIconData(0xeb4d, 'Duotone'),
   );
 
   /// ![chat-teardrop-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chat-teardrop-duotone.svg)
   static const chatTeardrop = PhosphorDuotoneIconData(
     0xeb5a,
-    PhosphorIconData(0xeb59, 'duotone'),
+    PhosphorIconData(0xeb59, 'Duotone'),
   );
 
   /// ![chat-teardrop-dots-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chat-teardrop-dots-duotone.svg)
   static const chatTeardropDots = PhosphorDuotoneIconData(
     0xeb58,
-    PhosphorIconData(0xeb57, 'duotone'),
+    PhosphorIconData(0xeb57, 'Duotone'),
   );
 
   /// ![chat-teardrop-text-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chat-teardrop-text-duotone.svg)
   static const chatTeardropText = PhosphorDuotoneIconData(
     0xeb5c,
-    PhosphorIconData(0xeb5b, 'duotone'),
+    PhosphorIconData(0xeb5b, 'Duotone'),
   );
 
   /// ![chat-text-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chat-text-duotone.svg)
   static const chatText = PhosphorDuotoneIconData(
     0xeb5e,
-    PhosphorIconData(0xeb5d, 'duotone'),
+    PhosphorIconData(0xeb5d, 'Duotone'),
   );
 
   /// ![chats-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chats-duotone.svg)
   static const chats = PhosphorDuotoneIconData(
     0xeb54,
-    PhosphorIconData(0xeb53, 'duotone'),
+    PhosphorIconData(0xeb53, 'Duotone'),
   );
 
   /// ![chats-circle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chats-circle-duotone.svg)
   static const chatsCircle = PhosphorDuotoneIconData(
     0xeb52,
-    PhosphorIconData(0xeb51, 'duotone'),
+    PhosphorIconData(0xeb51, 'Duotone'),
   );
 
   /// ![chats-teardrop-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chats-teardrop-duotone.svg)
   static const chatsTeardrop = PhosphorDuotoneIconData(
     0xeb56,
-    PhosphorIconData(0xeb55, 'duotone'),
+    PhosphorIconData(0xeb55, 'Duotone'),
   );
 
   /// ![check-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/check-duotone.svg)
   static const check = PhosphorDuotoneIconData(
     0xeb62,
-    PhosphorIconData(0xeb61, 'duotone'),
+    PhosphorIconData(0xeb61, 'Duotone'),
   );
 
   /// ![check-circle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/check-circle-duotone.svg)
   static const checkCircle = PhosphorDuotoneIconData(
     0xeb60,
-    PhosphorIconData(0xeb5f, 'duotone'),
+    PhosphorIconData(0xeb5f, 'Duotone'),
   );
 
   /// ![check-fat-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/check-fat-duotone.svg)
   static const checkFat = PhosphorDuotoneIconData(
     0xeb64,
-    PhosphorIconData(0xeb63, 'duotone'),
+    PhosphorIconData(0xeb63, 'Duotone'),
   );
 
   /// ![check-square-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/check-square-duotone.svg)
   static const checkSquare = PhosphorDuotoneIconData(
     0xeb68,
-    PhosphorIconData(0xeb67, 'duotone'),
+    PhosphorIconData(0xeb67, 'Duotone'),
   );
 
   /// ![check-square-offset-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/check-square-offset-duotone.svg)
   static const checkSquareOffset = PhosphorDuotoneIconData(
     0xeb6a,
-    PhosphorIconData(0xeb69, 'duotone'),
+    PhosphorIconData(0xeb69, 'Duotone'),
   );
 
   /// ![checks-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/checks-duotone.svg)
   static const checks = PhosphorDuotoneIconData(
     0xeb66,
-    PhosphorIconData(0xeb65, 'duotone'),
+    PhosphorIconData(0xeb65, 'Duotone'),
   );
 
   /// ![church-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/church-duotone.svg)
   static const church = PhosphorDuotoneIconData(
     0xeb6c,
-    PhosphorIconData(0xeb6b, 'duotone'),
+    PhosphorIconData(0xeb6b, 'Duotone'),
   );
 
   /// ![circle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/circle-duotone.svg)
   static const circle = PhosphorDuotoneIconData(
     0xeb70,
-    PhosphorIconData(0xeb6f, 'duotone'),
+    PhosphorIconData(0xeb6f, 'Duotone'),
   );
 
   /// ![circle-dashed-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/circle-dashed-duotone.svg)
   static const circleDashed = PhosphorDuotoneIconData(
     0xeb6e,
-    PhosphorIconData(0xeb6d, 'duotone'),
+    PhosphorIconData(0xeb6d, 'Duotone'),
   );
 
   /// ![circle-half-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/circle-half-duotone.svg)
   static const circleHalf = PhosphorDuotoneIconData(
     0xeb72,
-    PhosphorIconData(0xeb71, 'duotone'),
+    PhosphorIconData(0xeb71, 'Duotone'),
   );
 
   /// ![circle-half-tilt-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/circle-half-tilt-duotone.svg)
   static const circleHalfTilt = PhosphorDuotoneIconData(
     0xeb74,
-    PhosphorIconData(0xeb73, 'duotone'),
+    PhosphorIconData(0xeb73, 'Duotone'),
   );
 
   /// ![circle-notch-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/circle-notch-duotone.svg)
   static const circleNotch = PhosphorDuotoneIconData(
     0xeb76,
-    PhosphorIconData(0xeb75, 'duotone'),
+    PhosphorIconData(0xeb75, 'Duotone'),
   );
 
   /// ![circles-four-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/circles-four-duotone.svg)
   static const circlesFour = PhosphorDuotoneIconData(
     0xeb78,
-    PhosphorIconData(0xeb77, 'duotone'),
+    PhosphorIconData(0xeb77, 'Duotone'),
   );
 
   /// ![circles-three-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/circles-three-duotone.svg)
   static const circlesThree = PhosphorDuotoneIconData(
     0xeb7a,
-    PhosphorIconData(0xeb79, 'duotone'),
+    PhosphorIconData(0xeb79, 'Duotone'),
   );
 
   /// ![circles-three-plus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/circles-three-plus-duotone.svg)
   static const circlesThreePlus = PhosphorDuotoneIconData(
     0xeb7c,
-    PhosphorIconData(0xeb7b, 'duotone'),
+    PhosphorIconData(0xeb7b, 'Duotone'),
   );
 
   /// ![circuitry-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/circuitry-duotone.svg)
   static const circuitry = PhosphorDuotoneIconData(
     0xeb7e,
-    PhosphorIconData(0xeb7d, 'duotone'),
+    PhosphorIconData(0xeb7d, 'Duotone'),
   );
 
   /// ![clipboard-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/clipboard-duotone.svg)
   static const clipboard = PhosphorDuotoneIconData(
     0xeb80,
-    PhosphorIconData(0xeb7f, 'duotone'),
+    PhosphorIconData(0xeb7f, 'Duotone'),
   );
 
   /// ![clipboard-text-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/clipboard-text-duotone.svg)
   static const clipboardText = PhosphorDuotoneIconData(
     0xeb82,
-    PhosphorIconData(0xeb81, 'duotone'),
+    PhosphorIconData(0xeb81, 'Duotone'),
   );
 
   /// ![clock-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/clock-duotone.svg)
   static const clock = PhosphorDuotoneIconData(
     0xeb8c,
-    PhosphorIconData(0xeb8b, 'duotone'),
+    PhosphorIconData(0xeb8b, 'Duotone'),
   );
 
   /// ![clock-afternoon-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/clock-afternoon-duotone.svg)
   static const clockAfternoon = PhosphorDuotoneIconData(
     0xeb84,
-    PhosphorIconData(0xeb83, 'duotone'),
+    PhosphorIconData(0xeb83, 'Duotone'),
   );
 
   /// ![clock-clockwise-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/clock-clockwise-duotone.svg)
   static const clockClockwise = PhosphorDuotoneIconData(
     0xeb86,
-    PhosphorIconData(0xeb85, 'duotone'),
+    PhosphorIconData(0xeb85, 'Duotone'),
   );
 
   /// ![clock-countdown-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/clock-countdown-duotone.svg)
   static const clockCountdown = PhosphorDuotoneIconData(
     0xeb88,
-    PhosphorIconData(0xeb87, 'duotone'),
+    PhosphorIconData(0xeb87, 'Duotone'),
   );
 
   /// ![clock-counter-clockwise-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/clock-counter-clockwise-duotone.svg)
   static const clockCounterClockwise = PhosphorDuotoneIconData(
     0xeb8a,
-    PhosphorIconData(0xeb89, 'duotone'),
+    PhosphorIconData(0xeb89, 'Duotone'),
   );
 
   /// ![closed-captioning-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/closed-captioning-duotone.svg)
   static const closedCaptioning = PhosphorDuotoneIconData(
     0xeb8e,
-    PhosphorIconData(0xeb8d, 'duotone'),
+    PhosphorIconData(0xeb8d, 'Duotone'),
   );
 
   /// ![cloud-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cloud-duotone.svg)
   static const cloud = PhosphorDuotoneIconData(
     0xeb96,
-    PhosphorIconData(0xeb95, 'duotone'),
+    PhosphorIconData(0xeb95, 'Duotone'),
   );
 
   /// ![cloud-arrow-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cloud-arrow-down-duotone.svg)
   static const cloudArrowDown = PhosphorDuotoneIconData(
     0xeb90,
-    PhosphorIconData(0xeb8f, 'duotone'),
+    PhosphorIconData(0xeb8f, 'Duotone'),
   );
 
   /// ![cloud-arrow-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cloud-arrow-up-duotone.svg)
   static const cloudArrowUp = PhosphorDuotoneIconData(
     0xeb92,
-    PhosphorIconData(0xeb91, 'duotone'),
+    PhosphorIconData(0xeb91, 'Duotone'),
   );
 
   /// ![cloud-check-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cloud-check-duotone.svg)
   static const cloudCheck = PhosphorDuotoneIconData(
     0xeb94,
-    PhosphorIconData(0xeb93, 'duotone'),
+    PhosphorIconData(0xeb93, 'Duotone'),
   );
 
   /// ![cloud-fog-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cloud-fog-duotone.svg)
   static const cloudFog = PhosphorDuotoneIconData(
     0xeb98,
-    PhosphorIconData(0xeb97, 'duotone'),
+    PhosphorIconData(0xeb97, 'Duotone'),
   );
 
   /// ![cloud-lightning-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cloud-lightning-duotone.svg)
   static const cloudLightning = PhosphorDuotoneIconData(
     0xeb9a,
-    PhosphorIconData(0xeb99, 'duotone'),
+    PhosphorIconData(0xeb99, 'Duotone'),
   );
 
   /// ![cloud-moon-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cloud-moon-duotone.svg)
   static const cloudMoon = PhosphorDuotoneIconData(
     0xeb9c,
-    PhosphorIconData(0xeb9b, 'duotone'),
+    PhosphorIconData(0xeb9b, 'Duotone'),
   );
 
   /// ![cloud-rain-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cloud-rain-duotone.svg)
   static const cloudRain = PhosphorDuotoneIconData(
     0xeb9e,
-    PhosphorIconData(0xeb9d, 'duotone'),
+    PhosphorIconData(0xeb9d, 'Duotone'),
   );
 
   /// ![cloud-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cloud-slash-duotone.svg)
   static const cloudSlash = PhosphorDuotoneIconData(
     0xeba0,
-    PhosphorIconData(0xeb9f, 'duotone'),
+    PhosphorIconData(0xeb9f, 'Duotone'),
   );
 
   /// ![cloud-snow-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cloud-snow-duotone.svg)
   static const cloudSnow = PhosphorDuotoneIconData(
     0xeba2,
-    PhosphorIconData(0xeba1, 'duotone'),
+    PhosphorIconData(0xeba1, 'Duotone'),
   );
 
   /// ![cloud-sun-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cloud-sun-duotone.svg)
   static const cloudSun = PhosphorDuotoneIconData(
     0xeba4,
-    PhosphorIconData(0xeba3, 'duotone'),
+    PhosphorIconData(0xeba3, 'Duotone'),
   );
 
   /// ![cloud-warning-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cloud-warning-duotone.svg)
   static const cloudWarning = PhosphorDuotoneIconData(
     0xeba6,
-    PhosphorIconData(0xeba5, 'duotone'),
+    PhosphorIconData(0xeba5, 'Duotone'),
   );
 
   /// ![cloud-x-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cloud-x-duotone.svg)
   static const cloudX = PhosphorDuotoneIconData(
     0xeba8,
-    PhosphorIconData(0xeba7, 'duotone'),
+    PhosphorIconData(0xeba7, 'Duotone'),
   );
 
   /// ![club-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/club-duotone.svg)
   static const club = PhosphorDuotoneIconData(
     0xebaa,
-    PhosphorIconData(0xeba9, 'duotone'),
+    PhosphorIconData(0xeba9, 'Duotone'),
   );
 
   /// ![coat-hanger-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/coat-hanger-duotone.svg)
   static const coatHanger = PhosphorDuotoneIconData(
     0xebac,
-    PhosphorIconData(0xebab, 'duotone'),
+    PhosphorIconData(0xebab, 'Duotone'),
   );
 
   /// ![coda-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/coda-logo-duotone.svg)
   static const codaLogo = PhosphorDuotoneIconData(
     0xebae,
-    PhosphorIconData(0xebad, 'duotone'),
+    PhosphorIconData(0xebad, 'Duotone'),
   );
 
   /// ![code-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/code-duotone.svg)
   static const code = PhosphorDuotoneIconData(
     0xebb2,
-    PhosphorIconData(0xebb1, 'duotone'),
+    PhosphorIconData(0xebb1, 'Duotone'),
   );
 
   /// ![code-block-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/code-block-duotone.svg)
   static const codeBlock = PhosphorDuotoneIconData(
     0xebb0,
-    PhosphorIconData(0xebaf, 'duotone'),
+    PhosphorIconData(0xebaf, 'Duotone'),
   );
 
   /// ![code-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/code-simple-duotone.svg)
   static const codeSimple = PhosphorDuotoneIconData(
     0xebb8,
-    PhosphorIconData(0xebb7, 'duotone'),
+    PhosphorIconData(0xebb7, 'Duotone'),
   );
 
   /// ![codepen-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/codepen-logo-duotone.svg)
   static const codepenLogo = PhosphorDuotoneIconData(
     0xebb4,
-    PhosphorIconData(0xebb3, 'duotone'),
+    PhosphorIconData(0xebb3, 'Duotone'),
   );
 
   /// ![codesandbox-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/codesandbox-logo-duotone.svg)
   static const codesandboxLogo = PhosphorDuotoneIconData(
     0xebb6,
-    PhosphorIconData(0xebb5, 'duotone'),
+    PhosphorIconData(0xebb5, 'Duotone'),
   );
 
   /// ![coffee-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/coffee-duotone.svg)
   static const coffee = PhosphorDuotoneIconData(
     0xebba,
-    PhosphorIconData(0xebb9, 'duotone'),
+    PhosphorIconData(0xebb9, 'Duotone'),
   );
 
   /// ![coin-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/coin-duotone.svg)
   static const coin = PhosphorDuotoneIconData(
     0xebbc,
-    PhosphorIconData(0xebbb, 'duotone'),
+    PhosphorIconData(0xebbb, 'Duotone'),
   );
 
   /// ![coin-vertical-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/coin-vertical-duotone.svg)
   static const coinVertical = PhosphorDuotoneIconData(
     0xebc0,
-    PhosphorIconData(0xebbf, 'duotone'),
+    PhosphorIconData(0xebbf, 'Duotone'),
   );
 
   /// ![coins-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/coins-duotone.svg)
   static const coins = PhosphorDuotoneIconData(
     0xebbe,
-    PhosphorIconData(0xebbd, 'duotone'),
+    PhosphorIconData(0xebbd, 'Duotone'),
   );
 
   /// ![columns-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/columns-duotone.svg)
   static const columns = PhosphorDuotoneIconData(
     0xebc2,
-    PhosphorIconData(0xebc1, 'duotone'),
+    PhosphorIconData(0xebc1, 'Duotone'),
   );
 
   /// ![command-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/command-duotone.svg)
   static const command = PhosphorDuotoneIconData(
     0xebc4,
-    PhosphorIconData(0xebc3, 'duotone'),
+    PhosphorIconData(0xebc3, 'Duotone'),
   );
 
   /// ![compass-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/compass-duotone.svg)
   static const compass = PhosphorDuotoneIconData(
     0xebc6,
-    PhosphorIconData(0xebc5, 'duotone'),
+    PhosphorIconData(0xebc5, 'Duotone'),
   );
 
   /// ![compass-tool-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/compass-tool-duotone.svg)
   static const compassTool = PhosphorDuotoneIconData(
     0xebc8,
-    PhosphorIconData(0xebc7, 'duotone'),
+    PhosphorIconData(0xebc7, 'Duotone'),
   );
 
   /// ![computer-tower-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/computer-tower-duotone.svg)
   static const computerTower = PhosphorDuotoneIconData(
     0xebca,
-    PhosphorIconData(0xebc9, 'duotone'),
+    PhosphorIconData(0xebc9, 'Duotone'),
   );
 
   /// ![confetti-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/confetti-duotone.svg)
   static const confetti = PhosphorDuotoneIconData(
     0xebcc,
-    PhosphorIconData(0xebcb, 'duotone'),
+    PhosphorIconData(0xebcb, 'Duotone'),
   );
 
   /// ![contactless-payment-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/contactless-payment-duotone.svg)
   static const contactlessPayment = PhosphorDuotoneIconData(
     0xebce,
-    PhosphorIconData(0xebcd, 'duotone'),
+    PhosphorIconData(0xebcd, 'Duotone'),
   );
 
   /// ![control-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/control-duotone.svg)
   static const control = PhosphorDuotoneIconData(
     0xebd0,
-    PhosphorIconData(0xebcf, 'duotone'),
+    PhosphorIconData(0xebcf, 'Duotone'),
   );
 
   /// ![cookie-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cookie-duotone.svg)
   static const cookie = PhosphorDuotoneIconData(
     0xebd2,
-    PhosphorIconData(0xebd1, 'duotone'),
+    PhosphorIconData(0xebd1, 'Duotone'),
   );
 
   /// ![cooking-pot-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cooking-pot-duotone.svg)
   static const cookingPot = PhosphorDuotoneIconData(
     0xebd4,
-    PhosphorIconData(0xebd3, 'duotone'),
+    PhosphorIconData(0xebd3, 'Duotone'),
   );
 
   /// ![copy-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/copy-duotone.svg)
   static const copy = PhosphorDuotoneIconData(
     0xebd6,
-    PhosphorIconData(0xebd5, 'duotone'),
+    PhosphorIconData(0xebd5, 'Duotone'),
   );
 
   /// ![copy-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/copy-simple-duotone.svg)
   static const copySimple = PhosphorDuotoneIconData(
     0xebdc,
-    PhosphorIconData(0xebdb, 'duotone'),
+    PhosphorIconData(0xebdb, 'Duotone'),
   );
 
   /// ![copyleft-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/copyleft-duotone.svg)
   static const copyleft = PhosphorDuotoneIconData(
     0xebd8,
-    PhosphorIconData(0xebd7, 'duotone'),
+    PhosphorIconData(0xebd7, 'Duotone'),
   );
 
   /// ![copyright-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/copyright-duotone.svg)
   static const copyright = PhosphorDuotoneIconData(
     0xebda,
-    PhosphorIconData(0xebd9, 'duotone'),
+    PhosphorIconData(0xebd9, 'Duotone'),
   );
 
   /// ![corners-in-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/corners-in-duotone.svg)
   static const cornersIn = PhosphorDuotoneIconData(
     0xebde,
-    PhosphorIconData(0xebdd, 'duotone'),
+    PhosphorIconData(0xebdd, 'Duotone'),
   );
 
   /// ![corners-out-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/corners-out-duotone.svg)
   static const cornersOut = PhosphorDuotoneIconData(
     0xebe0,
-    PhosphorIconData(0xebdf, 'duotone'),
+    PhosphorIconData(0xebdf, 'Duotone'),
   );
 
   /// ![couch-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/couch-duotone.svg)
   static const couch = PhosphorDuotoneIconData(
     0xebe2,
-    PhosphorIconData(0xebe1, 'duotone'),
+    PhosphorIconData(0xebe1, 'Duotone'),
   );
 
   /// ![cpu-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cpu-duotone.svg)
   static const cpu = PhosphorDuotoneIconData(
     0xebe4,
-    PhosphorIconData(0xebe3, 'duotone'),
+    PhosphorIconData(0xebe3, 'Duotone'),
   );
 
   /// ![credit-card-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/credit-card-duotone.svg)
   static const creditCard = PhosphorDuotoneIconData(
     0xebe6,
-    PhosphorIconData(0xebe5, 'duotone'),
+    PhosphorIconData(0xebe5, 'Duotone'),
   );
 
   /// ![crop-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/crop-duotone.svg)
   static const crop = PhosphorDuotoneIconData(
     0xebe8,
-    PhosphorIconData(0xebe7, 'duotone'),
+    PhosphorIconData(0xebe7, 'Duotone'),
   );
 
   /// ![cross-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cross-duotone.svg)
   static const cross = PhosphorDuotoneIconData(
     0xebea,
-    PhosphorIconData(0xebe9, 'duotone'),
+    PhosphorIconData(0xebe9, 'Duotone'),
   );
 
   /// ![crosshair-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/crosshair-duotone.svg)
   static const crosshair = PhosphorDuotoneIconData(
     0xebec,
-    PhosphorIconData(0xebeb, 'duotone'),
+    PhosphorIconData(0xebeb, 'Duotone'),
   );
 
   /// ![crosshair-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/crosshair-simple-duotone.svg)
   static const crosshairSimple = PhosphorDuotoneIconData(
     0xebee,
-    PhosphorIconData(0xebed, 'duotone'),
+    PhosphorIconData(0xebed, 'Duotone'),
   );
 
   /// ![crown-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/crown-duotone.svg)
   static const crown = PhosphorDuotoneIconData(
     0xebf0,
-    PhosphorIconData(0xebef, 'duotone'),
+    PhosphorIconData(0xebef, 'Duotone'),
   );
 
   /// ![crown-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/crown-simple-duotone.svg)
   static const crownSimple = PhosphorDuotoneIconData(
     0xebf2,
-    PhosphorIconData(0xebf1, 'duotone'),
+    PhosphorIconData(0xebf1, 'Duotone'),
   );
 
   /// ![cube-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cube-duotone.svg)
   static const cube = PhosphorDuotoneIconData(
     0xebf4,
-    PhosphorIconData(0xebf3, 'duotone'),
+    PhosphorIconData(0xebf3, 'Duotone'),
   );
 
   /// ![cube-focus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cube-focus-duotone.svg)
   static const cubeFocus = PhosphorDuotoneIconData(
     0xebf6,
-    PhosphorIconData(0xebf5, 'duotone'),
+    PhosphorIconData(0xebf5, 'Duotone'),
   );
 
   /// ![cube-transparent-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cube-transparent-duotone.svg)
   static const cubeTransparent = PhosphorDuotoneIconData(
     0xebf8,
-    PhosphorIconData(0xebf7, 'duotone'),
+    PhosphorIconData(0xebf7, 'Duotone'),
   );
 
   /// ![currency-btc-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/currency-btc-duotone.svg)
   static const currencyBtc = PhosphorDuotoneIconData(
     0xebfa,
-    PhosphorIconData(0xebf9, 'duotone'),
+    PhosphorIconData(0xebf9, 'Duotone'),
   );
 
   /// ![currency-circle-dollar-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/currency-circle-dollar-duotone.svg)
   static const currencyCircleDollar = PhosphorDuotoneIconData(
     0xebfc,
-    PhosphorIconData(0xebfb, 'duotone'),
+    PhosphorIconData(0xebfb, 'Duotone'),
   );
 
   /// ![currency-cny-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/currency-cny-duotone.svg)
   static const currencyCny = PhosphorDuotoneIconData(
     0xebfe,
-    PhosphorIconData(0xebfd, 'duotone'),
+    PhosphorIconData(0xebfd, 'Duotone'),
   );
 
   /// ![currency-dollar-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/currency-dollar-duotone.svg)
   static const currencyDollar = PhosphorDuotoneIconData(
     0xec00,
-    PhosphorIconData(0xebff, 'duotone'),
+    PhosphorIconData(0xebff, 'Duotone'),
   );
 
   /// ![currency-dollar-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/currency-dollar-simple-duotone.svg)
   static const currencyDollarSimple = PhosphorDuotoneIconData(
     0xec02,
-    PhosphorIconData(0xec01, 'duotone'),
+    PhosphorIconData(0xec01, 'Duotone'),
   );
 
   /// ![currency-eth-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/currency-eth-duotone.svg)
   static const currencyEth = PhosphorDuotoneIconData(
     0xec04,
-    PhosphorIconData(0xec03, 'duotone'),
+    PhosphorIconData(0xec03, 'Duotone'),
   );
 
   /// ![currency-eur-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/currency-eur-duotone.svg)
   static const currencyEur = PhosphorDuotoneIconData(
     0xec06,
-    PhosphorIconData(0xec05, 'duotone'),
+    PhosphorIconData(0xec05, 'Duotone'),
   );
 
   /// ![currency-gbp-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/currency-gbp-duotone.svg)
   static const currencyGbp = PhosphorDuotoneIconData(
     0xec08,
-    PhosphorIconData(0xec07, 'duotone'),
+    PhosphorIconData(0xec07, 'Duotone'),
   );
 
   /// ![currency-inr-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/currency-inr-duotone.svg)
   static const currencyInr = PhosphorDuotoneIconData(
     0xec0a,
-    PhosphorIconData(0xec09, 'duotone'),
+    PhosphorIconData(0xec09, 'Duotone'),
   );
 
   /// ![currency-jpy-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/currency-jpy-duotone.svg)
   static const currencyJpy = PhosphorDuotoneIconData(
     0xec0c,
-    PhosphorIconData(0xec0b, 'duotone'),
+    PhosphorIconData(0xec0b, 'Duotone'),
   );
 
   /// ![currency-krw-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/currency-krw-duotone.svg)
   static const currencyKrw = PhosphorDuotoneIconData(
     0xec0e,
-    PhosphorIconData(0xec0d, 'duotone'),
+    PhosphorIconData(0xec0d, 'Duotone'),
   );
 
   /// ![currency-kzt-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/currency-kzt-duotone.svg)
   static const currencyKzt = PhosphorDuotoneIconData(
     0xec10,
-    PhosphorIconData(0xec0f, 'duotone'),
+    PhosphorIconData(0xec0f, 'Duotone'),
   );
 
   /// ![currency-ngn-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/currency-ngn-duotone.svg)
   static const currencyNgn = PhosphorDuotoneIconData(
     0xec12,
-    PhosphorIconData(0xec11, 'duotone'),
+    PhosphorIconData(0xec11, 'Duotone'),
   );
 
   /// ![currency-rub-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/currency-rub-duotone.svg)
   static const currencyRub = PhosphorDuotoneIconData(
     0xec14,
-    PhosphorIconData(0xec13, 'duotone'),
+    PhosphorIconData(0xec13, 'Duotone'),
   );
 
   /// ![cursor-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cursor-duotone.svg)
   static const cursor = PhosphorDuotoneIconData(
     0xec18,
-    PhosphorIconData(0xec17, 'duotone'),
+    PhosphorIconData(0xec17, 'Duotone'),
   );
 
   /// ![cursor-click-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cursor-click-duotone.svg)
   static const cursorClick = PhosphorDuotoneIconData(
     0xec16,
-    PhosphorIconData(0xec15, 'duotone'),
+    PhosphorIconData(0xec15, 'Duotone'),
   );
 
   /// ![cursor-text-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cursor-text-duotone.svg)
   static const cursorText = PhosphorDuotoneIconData(
     0xec1a,
-    PhosphorIconData(0xec19, 'duotone'),
+    PhosphorIconData(0xec19, 'Duotone'),
   );
 
   /// ![cylinder-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cylinder-duotone.svg)
   static const cylinder = PhosphorDuotoneIconData(
     0xec1c,
-    PhosphorIconData(0xec1b, 'duotone'),
+    PhosphorIconData(0xec1b, 'Duotone'),
   );
 
   /// ![database-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/database-duotone.svg)
   static const database = PhosphorDuotoneIconData(
     0xec1e,
-    PhosphorIconData(0xec1d, 'duotone'),
+    PhosphorIconData(0xec1d, 'Duotone'),
   );
 
   /// ![desktop-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/desktop-duotone.svg)
   static const desktop = PhosphorDuotoneIconData(
     0xec20,
-    PhosphorIconData(0xec1f, 'duotone'),
+    PhosphorIconData(0xec1f, 'Duotone'),
   );
 
   /// ![desktop-tower-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/desktop-tower-duotone.svg)
   static const desktopTower = PhosphorDuotoneIconData(
     0xec22,
-    PhosphorIconData(0xec21, 'duotone'),
+    PhosphorIconData(0xec21, 'Duotone'),
   );
 
   /// ![detective-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/detective-duotone.svg)
   static const detective = PhosphorDuotoneIconData(
     0xec24,
-    PhosphorIconData(0xec23, 'duotone'),
+    PhosphorIconData(0xec23, 'Duotone'),
   );
 
   /// ![dev-to-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/dev-to-logo-duotone.svg)
   static const devToLogo = PhosphorDuotoneIconData(
     0xec34,
-    PhosphorIconData(0xec33, 'duotone'),
+    PhosphorIconData(0xec33, 'Duotone'),
   );
 
   /// ![device-mobile-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/device-mobile-duotone.svg)
   static const deviceMobile = PhosphorDuotoneIconData(
     0xec28,
-    PhosphorIconData(0xec27, 'duotone'),
+    PhosphorIconData(0xec27, 'Duotone'),
   );
 
   /// ![device-mobile-camera-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/device-mobile-camera-duotone.svg)
   static const deviceMobileCamera = PhosphorDuotoneIconData(
     0xec26,
-    PhosphorIconData(0xec25, 'duotone'),
+    PhosphorIconData(0xec25, 'Duotone'),
   );
 
   /// ![device-mobile-speaker-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/device-mobile-speaker-duotone.svg)
   static const deviceMobileSpeaker = PhosphorDuotoneIconData(
     0xec2a,
-    PhosphorIconData(0xec29, 'duotone'),
+    PhosphorIconData(0xec29, 'Duotone'),
   );
 
   /// ![device-tablet-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/device-tablet-duotone.svg)
   static const deviceTablet = PhosphorDuotoneIconData(
     0xec30,
-    PhosphorIconData(0xec2f, 'duotone'),
+    PhosphorIconData(0xec2f, 'Duotone'),
   );
 
   /// ![device-tablet-camera-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/device-tablet-camera-duotone.svg)
   static const deviceTabletCamera = PhosphorDuotoneIconData(
     0xec2e,
-    PhosphorIconData(0xec2d, 'duotone'),
+    PhosphorIconData(0xec2d, 'Duotone'),
   );
 
   /// ![device-tablet-speaker-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/device-tablet-speaker-duotone.svg)
   static const deviceTabletSpeaker = PhosphorDuotoneIconData(
     0xec32,
-    PhosphorIconData(0xec31, 'duotone'),
+    PhosphorIconData(0xec31, 'Duotone'),
   );
 
   /// ![devices-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/devices-duotone.svg)
   static const devices = PhosphorDuotoneIconData(
     0xec2c,
-    PhosphorIconData(0xec2b, 'duotone'),
+    PhosphorIconData(0xec2b, 'Duotone'),
   );
 
   /// ![diamond-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/diamond-duotone.svg)
   static const diamond = PhosphorDuotoneIconData(
     0xec36,
-    PhosphorIconData(0xec35, 'duotone'),
+    PhosphorIconData(0xec35, 'Duotone'),
   );
 
   /// ![diamonds-four-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/diamonds-four-duotone.svg)
   static const diamondsFour = PhosphorDuotoneIconData(
     0xec38,
-    PhosphorIconData(0xec37, 'duotone'),
+    PhosphorIconData(0xec37, 'Duotone'),
   );
 
   /// ![dice-five-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/dice-five-duotone.svg)
   static const diceFive = PhosphorDuotoneIconData(
     0xec3a,
-    PhosphorIconData(0xec39, 'duotone'),
+    PhosphorIconData(0xec39, 'Duotone'),
   );
 
   /// ![dice-four-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/dice-four-duotone.svg)
   static const diceFour = PhosphorDuotoneIconData(
     0xec3c,
-    PhosphorIconData(0xec3b, 'duotone'),
+    PhosphorIconData(0xec3b, 'Duotone'),
   );
 
   /// ![dice-one-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/dice-one-duotone.svg)
   static const diceOne = PhosphorDuotoneIconData(
     0xec3e,
-    PhosphorIconData(0xec3d, 'duotone'),
+    PhosphorIconData(0xec3d, 'Duotone'),
   );
 
   /// ![dice-six-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/dice-six-duotone.svg)
   static const diceSix = PhosphorDuotoneIconData(
     0xec40,
-    PhosphorIconData(0xec3f, 'duotone'),
+    PhosphorIconData(0xec3f, 'Duotone'),
   );
 
   /// ![dice-three-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/dice-three-duotone.svg)
   static const diceThree = PhosphorDuotoneIconData(
     0xec42,
-    PhosphorIconData(0xec41, 'duotone'),
+    PhosphorIconData(0xec41, 'Duotone'),
   );
 
   /// ![dice-two-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/dice-two-duotone.svg)
   static const diceTwo = PhosphorDuotoneIconData(
     0xec44,
-    PhosphorIconData(0xec43, 'duotone'),
+    PhosphorIconData(0xec43, 'Duotone'),
   );
 
   /// ![disc-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/disc-duotone.svg)
   static const disc = PhosphorDuotoneIconData(
     0xec46,
-    PhosphorIconData(0xec45, 'duotone'),
+    PhosphorIconData(0xec45, 'Duotone'),
   );
 
   /// ![discord-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/discord-logo-duotone.svg)
   static const discordLogo = PhosphorDuotoneIconData(
     0xec48,
-    PhosphorIconData(0xec47, 'duotone'),
+    PhosphorIconData(0xec47, 'Duotone'),
   );
 
   /// ![divide-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/divide-duotone.svg)
   static const divide = PhosphorDuotoneIconData(
     0xec4a,
-    PhosphorIconData(0xec49, 'duotone'),
+    PhosphorIconData(0xec49, 'Duotone'),
   );
 
   /// ![dna-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/dna-duotone.svg)
   static const dna = PhosphorDuotoneIconData(
     0xec4c,
-    PhosphorIconData(0xec4b, 'duotone'),
+    PhosphorIconData(0xec4b, 'Duotone'),
   );
 
   /// ![dog-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/dog-duotone.svg)
   static const dog = PhosphorDuotoneIconData(
     0xec4e,
-    PhosphorIconData(0xec4d, 'duotone'),
+    PhosphorIconData(0xec4d, 'Duotone'),
   );
 
   /// ![door-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/door-duotone.svg)
   static const door = PhosphorDuotoneIconData(
     0xec50,
-    PhosphorIconData(0xec4f, 'duotone'),
+    PhosphorIconData(0xec4f, 'Duotone'),
   );
 
   /// ![door-open-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/door-open-duotone.svg)
   static const doorOpen = PhosphorDuotoneIconData(
     0xec52,
-    PhosphorIconData(0xec51, 'duotone'),
+    PhosphorIconData(0xec51, 'Duotone'),
   );
 
   /// ![dot-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/dot-duotone.svg)
   static const dot = PhosphorDuotoneIconData(
     0xec54,
-    PhosphorIconData(0xec53, 'duotone'),
+    PhosphorIconData(0xec53, 'Duotone'),
   );
 
   /// ![dot-outline-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/dot-outline-duotone.svg)
   static const dotOutline = PhosphorDuotoneIconData(
     0xec56,
-    PhosphorIconData(0xec55, 'duotone'),
+    PhosphorIconData(0xec55, 'Duotone'),
   );
 
   /// ![dots-nine-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/dots-nine-duotone.svg)
   static const dotsNine = PhosphorDuotoneIconData(
     0xec58,
-    PhosphorIconData(0xec57, 'duotone'),
+    PhosphorIconData(0xec57, 'Duotone'),
   );
 
   /// ![dots-six-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/dots-six-duotone.svg)
   static const dotsSix = PhosphorDuotoneIconData(
     0xec5a,
-    PhosphorIconData(0xec59, 'duotone'),
+    PhosphorIconData(0xec59, 'Duotone'),
   );
 
   /// ![dots-six-vertical-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/dots-six-vertical-duotone.svg)
   static const dotsSixVertical = PhosphorDuotoneIconData(
     0xec5c,
-    PhosphorIconData(0xec5b, 'duotone'),
+    PhosphorIconData(0xec5b, 'Duotone'),
   );
 
   /// ![dots-three-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/dots-three-duotone.svg)
   static const dotsThree = PhosphorDuotoneIconData(
     0xec62,
-    PhosphorIconData(0xec61, 'duotone'),
+    PhosphorIconData(0xec61, 'Duotone'),
   );
 
   /// ![dots-three-circle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/dots-three-circle-duotone.svg)
   static const dotsThreeCircle = PhosphorDuotoneIconData(
     0xec5e,
-    PhosphorIconData(0xec5d, 'duotone'),
+    PhosphorIconData(0xec5d, 'Duotone'),
   );
 
   /// ![dots-three-circle-vertical-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/dots-three-circle-vertical-duotone.svg)
   static const dotsThreeCircleVertical = PhosphorDuotoneIconData(
     0xec60,
-    PhosphorIconData(0xec5f, 'duotone'),
+    PhosphorIconData(0xec5f, 'Duotone'),
   );
 
   /// ![dots-three-outline-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/dots-three-outline-duotone.svg)
   static const dotsThreeOutline = PhosphorDuotoneIconData(
     0xec64,
-    PhosphorIconData(0xec63, 'duotone'),
+    PhosphorIconData(0xec63, 'Duotone'),
   );
 
   /// ![dots-three-outline-vertical-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/dots-three-outline-vertical-duotone.svg)
   static const dotsThreeOutlineVertical = PhosphorDuotoneIconData(
     0xec66,
-    PhosphorIconData(0xec65, 'duotone'),
+    PhosphorIconData(0xec65, 'Duotone'),
   );
 
   /// ![dots-three-vertical-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/dots-three-vertical-duotone.svg)
   static const dotsThreeVertical = PhosphorDuotoneIconData(
     0xec68,
-    PhosphorIconData(0xec67, 'duotone'),
+    PhosphorIconData(0xec67, 'Duotone'),
   );
 
   /// ![download-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/download-duotone.svg)
   static const download = PhosphorDuotoneIconData(
     0xec6a,
-    PhosphorIconData(0xec69, 'duotone'),
+    PhosphorIconData(0xec69, 'Duotone'),
   );
 
   /// ![download-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/download-simple-duotone.svg)
   static const downloadSimple = PhosphorDuotoneIconData(
     0xec6c,
-    PhosphorIconData(0xec6b, 'duotone'),
+    PhosphorIconData(0xec6b, 'Duotone'),
   );
 
   /// ![dress-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/dress-duotone.svg)
   static const dress = PhosphorDuotoneIconData(
     0xec6e,
-    PhosphorIconData(0xec6d, 'duotone'),
+    PhosphorIconData(0xec6d, 'Duotone'),
   );
 
   /// ![dribbble-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/dribbble-logo-duotone.svg)
   static const dribbbleLogo = PhosphorDuotoneIconData(
     0xec70,
-    PhosphorIconData(0xec6f, 'duotone'),
+    PhosphorIconData(0xec6f, 'Duotone'),
   );
 
   /// ![drop-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/drop-duotone.svg)
   static const drop = PhosphorDuotoneIconData(
     0xec74,
-    PhosphorIconData(0xec73, 'duotone'),
+    PhosphorIconData(0xec73, 'Duotone'),
   );
 
   /// ![drop-half-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/drop-half-duotone.svg)
   static const dropHalf = PhosphorDuotoneIconData(
     0xec78,
-    PhosphorIconData(0xec77, 'duotone'),
+    PhosphorIconData(0xec77, 'Duotone'),
   );
 
   /// ![drop-half-bottom-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/drop-half-bottom-duotone.svg)
   static const dropHalfBottom = PhosphorDuotoneIconData(
     0xec76,
-    PhosphorIconData(0xec75, 'duotone'),
+    PhosphorIconData(0xec75, 'Duotone'),
   );
 
   /// ![dropbox-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/dropbox-logo-duotone.svg)
   static const dropboxLogo = PhosphorDuotoneIconData(
     0xec72,
-    PhosphorIconData(0xec71, 'duotone'),
+    PhosphorIconData(0xec71, 'Duotone'),
   );
 
   /// ![ear-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/ear-duotone.svg)
   static const ear = PhosphorDuotoneIconData(
     0xec7a,
-    PhosphorIconData(0xec79, 'duotone'),
+    PhosphorIconData(0xec79, 'Duotone'),
   );
 
   /// ![ear-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/ear-slash-duotone.svg)
   static const earSlash = PhosphorDuotoneIconData(
     0xec7c,
-    PhosphorIconData(0xec7b, 'duotone'),
+    PhosphorIconData(0xec7b, 'Duotone'),
   );
 
   /// ![egg-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/egg-duotone.svg)
   static const egg = PhosphorDuotoneIconData(
     0xec80,
-    PhosphorIconData(0xec7f, 'duotone'),
+    PhosphorIconData(0xec7f, 'Duotone'),
   );
 
   /// ![egg-crack-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/egg-crack-duotone.svg)
   static const eggCrack = PhosphorDuotoneIconData(
     0xec7e,
-    PhosphorIconData(0xec7d, 'duotone'),
+    PhosphorIconData(0xec7d, 'Duotone'),
   );
 
   /// ![eject-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/eject-duotone.svg)
   static const eject = PhosphorDuotoneIconData(
     0xec82,
-    PhosphorIconData(0xec81, 'duotone'),
+    PhosphorIconData(0xec81, 'Duotone'),
   );
 
   /// ![eject-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/eject-simple-duotone.svg)
   static const ejectSimple = PhosphorDuotoneIconData(
     0xec84,
-    PhosphorIconData(0xec83, 'duotone'),
+    PhosphorIconData(0xec83, 'Duotone'),
   );
 
   /// ![elevator-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/elevator-duotone.svg)
   static const elevator = PhosphorDuotoneIconData(
     0xec86,
-    PhosphorIconData(0xec85, 'duotone'),
+    PhosphorIconData(0xec85, 'Duotone'),
   );
 
   /// ![engine-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/engine-duotone.svg)
   static const engine = PhosphorDuotoneIconData(
     0xec88,
-    PhosphorIconData(0xec87, 'duotone'),
+    PhosphorIconData(0xec87, 'Duotone'),
   );
 
   /// ![envelope-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/envelope-duotone.svg)
   static const envelope = PhosphorDuotoneIconData(
     0xec8a,
-    PhosphorIconData(0xec89, 'duotone'),
+    PhosphorIconData(0xec89, 'Duotone'),
   );
 
   /// ![envelope-open-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/envelope-open-duotone.svg)
   static const envelopeOpen = PhosphorDuotoneIconData(
     0xec8c,
-    PhosphorIconData(0xec8b, 'duotone'),
+    PhosphorIconData(0xec8b, 'Duotone'),
   );
 
   /// ![envelope-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/envelope-simple-duotone.svg)
   static const envelopeSimple = PhosphorDuotoneIconData(
     0xec8e,
-    PhosphorIconData(0xec8d, 'duotone'),
+    PhosphorIconData(0xec8d, 'Duotone'),
   );
 
   /// ![envelope-simple-open-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/envelope-simple-open-duotone.svg)
   static const envelopeSimpleOpen = PhosphorDuotoneIconData(
     0xec90,
-    PhosphorIconData(0xec8f, 'duotone'),
+    PhosphorIconData(0xec8f, 'Duotone'),
   );
 
   /// ![equalizer-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/equalizer-duotone.svg)
   static const equalizer = PhosphorDuotoneIconData(
     0xec92,
-    PhosphorIconData(0xec91, 'duotone'),
+    PhosphorIconData(0xec91, 'Duotone'),
   );
 
   /// ![equals-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/equals-duotone.svg)
   static const equals = PhosphorDuotoneIconData(
     0xec94,
-    PhosphorIconData(0xec93, 'duotone'),
+    PhosphorIconData(0xec93, 'Duotone'),
   );
 
   /// ![eraser-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/eraser-duotone.svg)
   static const eraser = PhosphorDuotoneIconData(
     0xec96,
-    PhosphorIconData(0xec95, 'duotone'),
+    PhosphorIconData(0xec95, 'Duotone'),
   );
 
   /// ![escalator-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/escalator-down-duotone.svg)
   static const escalatorDown = PhosphorDuotoneIconData(
     0xec98,
-    PhosphorIconData(0xec97, 'duotone'),
+    PhosphorIconData(0xec97, 'Duotone'),
   );
 
   /// ![escalator-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/escalator-up-duotone.svg)
   static const escalatorUp = PhosphorDuotoneIconData(
     0xec9a,
-    PhosphorIconData(0xec99, 'duotone'),
+    PhosphorIconData(0xec99, 'Duotone'),
   );
 
   /// ![exam-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/exam-duotone.svg)
   static const exam = PhosphorDuotoneIconData(
     0xec9c,
-    PhosphorIconData(0xec9b, 'duotone'),
+    PhosphorIconData(0xec9b, 'Duotone'),
   );
 
   /// ![exclude-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/exclude-duotone.svg)
   static const exclude = PhosphorDuotoneIconData(
     0xec9e,
-    PhosphorIconData(0xec9d, 'duotone'),
+    PhosphorIconData(0xec9d, 'Duotone'),
   );
 
   /// ![exclude-square-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/exclude-square-duotone.svg)
   static const excludeSquare = PhosphorDuotoneIconData(
     0xeca0,
-    PhosphorIconData(0xec9f, 'duotone'),
+    PhosphorIconData(0xec9f, 'Duotone'),
   );
 
   /// ![export-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/export-duotone.svg)
   static const export = PhosphorDuotoneIconData(
     0xeca2,
-    PhosphorIconData(0xeca1, 'duotone'),
+    PhosphorIconData(0xeca1, 'Duotone'),
   );
 
   /// ![eye-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/eye-duotone.svg)
   static const eye = PhosphorDuotoneIconData(
     0xecaa,
-    PhosphorIconData(0xeca9, 'duotone'),
+    PhosphorIconData(0xeca9, 'Duotone'),
   );
 
   /// ![eye-closed-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/eye-closed-duotone.svg)
   static const eyeClosed = PhosphorDuotoneIconData(
     0xeca4,
-    PhosphorIconData(0xeca3, 'duotone'),
+    PhosphorIconData(0xeca3, 'Duotone'),
   );
 
   /// ![eye-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/eye-slash-duotone.svg)
   static const eyeSlash = PhosphorDuotoneIconData(
     0xecae,
-    PhosphorIconData(0xecad, 'duotone'),
+    PhosphorIconData(0xecad, 'Duotone'),
   );
 
   /// ![eyedropper-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/eyedropper-duotone.svg)
   static const eyedropper = PhosphorDuotoneIconData(
     0xeca6,
-    PhosphorIconData(0xeca5, 'duotone'),
+    PhosphorIconData(0xeca5, 'Duotone'),
   );
 
   /// ![eyedropper-sample-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/eyedropper-sample-duotone.svg)
   static const eyedropperSample = PhosphorDuotoneIconData(
     0xeca8,
-    PhosphorIconData(0xeca7, 'duotone'),
+    PhosphorIconData(0xeca7, 'Duotone'),
   );
 
   /// ![eyeglasses-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/eyeglasses-duotone.svg)
   static const eyeglasses = PhosphorDuotoneIconData(
     0xecac,
-    PhosphorIconData(0xecab, 'duotone'),
+    PhosphorIconData(0xecab, 'Duotone'),
   );
 
   /// ![face-mask-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/face-mask-duotone.svg)
   static const faceMask = PhosphorDuotoneIconData(
     0xecb2,
-    PhosphorIconData(0xecb1, 'duotone'),
+    PhosphorIconData(0xecb1, 'Duotone'),
   );
 
   /// ![facebook-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/facebook-logo-duotone.svg)
   static const facebookLogo = PhosphorDuotoneIconData(
     0xecb0,
-    PhosphorIconData(0xecaf, 'duotone'),
+    PhosphorIconData(0xecaf, 'Duotone'),
   );
 
   /// ![factory-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/factory-duotone.svg)
   static const factory = PhosphorDuotoneIconData(
     0xecb4,
-    PhosphorIconData(0xecb3, 'duotone'),
+    PhosphorIconData(0xecb3, 'Duotone'),
   );
 
   /// ![faders-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/faders-duotone.svg)
   static const faders = PhosphorDuotoneIconData(
     0xecb6,
-    PhosphorIconData(0xecb5, 'duotone'),
+    PhosphorIconData(0xecb5, 'Duotone'),
   );
 
   /// ![faders-horizontal-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/faders-horizontal-duotone.svg)
   static const fadersHorizontal = PhosphorDuotoneIconData(
     0xecb8,
-    PhosphorIconData(0xecb7, 'duotone'),
+    PhosphorIconData(0xecb7, 'Duotone'),
   );
 
   /// ![fan-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/fan-duotone.svg)
   static const fan = PhosphorDuotoneIconData(
     0xecba,
-    PhosphorIconData(0xecb9, 'duotone'),
+    PhosphorIconData(0xecb9, 'Duotone'),
   );
 
   /// ![fast-forward-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/fast-forward-duotone.svg)
   static const fastForward = PhosphorDuotoneIconData(
     0xecbe,
-    PhosphorIconData(0xecbd, 'duotone'),
+    PhosphorIconData(0xecbd, 'Duotone'),
   );
 
   /// ![fast-forward-circle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/fast-forward-circle-duotone.svg)
   static const fastForwardCircle = PhosphorDuotoneIconData(
     0xecbc,
-    PhosphorIconData(0xecbb, 'duotone'),
+    PhosphorIconData(0xecbb, 'Duotone'),
   );
 
   /// ![feather-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/feather-duotone.svg)
   static const feather = PhosphorDuotoneIconData(
     0xecc0,
-    PhosphorIconData(0xecbf, 'duotone'),
+    PhosphorIconData(0xecbf, 'Duotone'),
   );
 
   /// ![figma-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/figma-logo-duotone.svg)
   static const figmaLogo = PhosphorDuotoneIconData(
     0xecc2,
-    PhosphorIconData(0xecc1, 'duotone'),
+    PhosphorIconData(0xecc1, 'Duotone'),
   );
 
   /// ![file-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-duotone.svg)
   static const file = PhosphorDuotoneIconData(
     0xecd8,
-    PhosphorIconData(0xecd7, 'duotone'),
+    PhosphorIconData(0xecd7, 'Duotone'),
   );
 
   /// ![file-archive-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-archive-duotone.svg)
   static const fileArchive = PhosphorDuotoneIconData(
     0xecc4,
-    PhosphorIconData(0xecc3, 'duotone'),
+    PhosphorIconData(0xecc3, 'Duotone'),
   );
 
   /// ![file-arrow-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-arrow-down-duotone.svg)
   static const fileArrowDown = PhosphorDuotoneIconData(
     0xecc6,
-    PhosphorIconData(0xecc5, 'duotone'),
+    PhosphorIconData(0xecc5, 'Duotone'),
   );
 
   /// ![file-arrow-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-arrow-up-duotone.svg)
   static const fileArrowUp = PhosphorDuotoneIconData(
     0xecc8,
-    PhosphorIconData(0xecc7, 'duotone'),
+    PhosphorIconData(0xecc7, 'Duotone'),
   );
 
   /// ![file-audio-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-audio-duotone.svg)
   static const fileAudio = PhosphorDuotoneIconData(
     0xecca,
-    PhosphorIconData(0xecc9, 'duotone'),
+    PhosphorIconData(0xecc9, 'Duotone'),
   );
 
   /// ![file-cloud-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-cloud-duotone.svg)
   static const fileCloud = PhosphorDuotoneIconData(
     0xeccc,
-    PhosphorIconData(0xeccb, 'duotone'),
+    PhosphorIconData(0xeccb, 'Duotone'),
   );
 
   /// ![file-code-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-code-duotone.svg)
   static const fileCode = PhosphorDuotoneIconData(
     0xecce,
-    PhosphorIconData(0xeccd, 'duotone'),
+    PhosphorIconData(0xeccd, 'Duotone'),
   );
 
   /// ![file-css-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-css-duotone.svg)
   static const fileCss = PhosphorDuotoneIconData(
     0xecd0,
-    PhosphorIconData(0xeccf, 'duotone'),
+    PhosphorIconData(0xeccf, 'Duotone'),
   );
 
   /// ![file-csv-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-csv-duotone.svg)
   static const fileCsv = PhosphorDuotoneIconData(
     0xecd2,
-    PhosphorIconData(0xecd1, 'duotone'),
+    PhosphorIconData(0xecd1, 'Duotone'),
   );
 
   /// ![file-dashed-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-dashed-duotone.svg)
   static const fileDashed = PhosphorDuotoneIconData(
     0xecd4,
-    PhosphorIconData(0xecd3, 'duotone'),
+    PhosphorIconData(0xecd3, 'Duotone'),
   );
 
   /// ![file-doc-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-doc-duotone.svg)
   static const fileDoc = PhosphorDuotoneIconData(
     0xecd6,
-    PhosphorIconData(0xecd5, 'duotone'),
+    PhosphorIconData(0xecd5, 'Duotone'),
   );
 
   /// ![file-html-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-html-duotone.svg)
   static const fileHtml = PhosphorDuotoneIconData(
     0xecda,
-    PhosphorIconData(0xecd9, 'duotone'),
+    PhosphorIconData(0xecd9, 'Duotone'),
   );
 
   /// ![file-image-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-image-duotone.svg)
   static const fileImage = PhosphorDuotoneIconData(
     0xecdc,
-    PhosphorIconData(0xecdb, 'duotone'),
+    PhosphorIconData(0xecdb, 'Duotone'),
   );
 
   /// ![file-jpg-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-jpg-duotone.svg)
   static const fileJpg = PhosphorDuotoneIconData(
     0xecde,
-    PhosphorIconData(0xecdd, 'duotone'),
+    PhosphorIconData(0xecdd, 'Duotone'),
   );
 
   /// ![file-js-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-js-duotone.svg)
   static const fileJs = PhosphorDuotoneIconData(
     0xece0,
-    PhosphorIconData(0xecdf, 'duotone'),
+    PhosphorIconData(0xecdf, 'Duotone'),
   );
 
   /// ![file-jsx-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-jsx-duotone.svg)
   static const fileJsx = PhosphorDuotoneIconData(
     0xece2,
-    PhosphorIconData(0xece1, 'duotone'),
+    PhosphorIconData(0xece1, 'Duotone'),
   );
 
   /// ![file-lock-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-lock-duotone.svg)
   static const fileLock = PhosphorDuotoneIconData(
     0xece4,
-    PhosphorIconData(0xece3, 'duotone'),
+    PhosphorIconData(0xece3, 'Duotone'),
   );
 
   /// ![file-magnifying-glass-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-magnifying-glass-duotone.svg)
   static const fileMagnifyingGlass = PhosphorDuotoneIconData(
     0xece6,
-    PhosphorIconData(0xece5, 'duotone'),
+    PhosphorIconData(0xece5, 'Duotone'),
   );
 
   /// ![file-minus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-minus-duotone.svg)
   static const fileMinus = PhosphorDuotoneIconData(
     0xece8,
-    PhosphorIconData(0xece7, 'duotone'),
+    PhosphorIconData(0xece7, 'Duotone'),
   );
 
   /// ![file-pdf-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-pdf-duotone.svg)
   static const filePdf = PhosphorDuotoneIconData(
     0xecea,
-    PhosphorIconData(0xece9, 'duotone'),
+    PhosphorIconData(0xece9, 'Duotone'),
   );
 
   /// ![file-plus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-plus-duotone.svg)
   static const filePlus = PhosphorDuotoneIconData(
     0xecec,
-    PhosphorIconData(0xeceb, 'duotone'),
+    PhosphorIconData(0xeceb, 'Duotone'),
   );
 
   /// ![file-png-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-png-duotone.svg)
   static const filePng = PhosphorDuotoneIconData(
     0xecee,
-    PhosphorIconData(0xeced, 'duotone'),
+    PhosphorIconData(0xeced, 'Duotone'),
   );
 
   /// ![file-ppt-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-ppt-duotone.svg)
   static const filePpt = PhosphorDuotoneIconData(
     0xecf0,
-    PhosphorIconData(0xecef, 'duotone'),
+    PhosphorIconData(0xecef, 'Duotone'),
   );
 
   /// ![file-rs-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-rs-duotone.svg)
   static const fileRs = PhosphorDuotoneIconData(
     0xecf2,
-    PhosphorIconData(0xecf1, 'duotone'),
+    PhosphorIconData(0xecf1, 'Duotone'),
   );
 
   /// ![file-sql-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-sql-duotone.svg)
   static const fileSql = PhosphorDuotoneIconData(
     0xecf6,
-    PhosphorIconData(0xecf5, 'duotone'),
+    PhosphorIconData(0xecf5, 'Duotone'),
   );
 
   /// ![file-svg-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-svg-duotone.svg)
   static const fileSvg = PhosphorDuotoneIconData(
     0xecf8,
-    PhosphorIconData(0xecf7, 'duotone'),
+    PhosphorIconData(0xecf7, 'Duotone'),
   );
 
   /// ![file-text-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-text-duotone.svg)
   static const fileText = PhosphorDuotoneIconData(
     0xecfa,
-    PhosphorIconData(0xecf9, 'duotone'),
+    PhosphorIconData(0xecf9, 'Duotone'),
   );
 
   /// ![file-ts-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-ts-duotone.svg)
   static const fileTs = PhosphorDuotoneIconData(
     0xecfc,
-    PhosphorIconData(0xecfb, 'duotone'),
+    PhosphorIconData(0xecfb, 'Duotone'),
   );
 
   /// ![file-tsx-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-tsx-duotone.svg)
   static const fileTsx = PhosphorDuotoneIconData(
     0xecfe,
-    PhosphorIconData(0xecfd, 'duotone'),
+    PhosphorIconData(0xecfd, 'Duotone'),
   );
 
   /// ![file-video-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-video-duotone.svg)
   static const fileVideo = PhosphorDuotoneIconData(
     0xed00,
-    PhosphorIconData(0xecff, 'duotone'),
+    PhosphorIconData(0xecff, 'Duotone'),
   );
 
   /// ![file-vue-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-vue-duotone.svg)
   static const fileVue = PhosphorDuotoneIconData(
     0xed02,
-    PhosphorIconData(0xed01, 'duotone'),
+    PhosphorIconData(0xed01, 'Duotone'),
   );
 
   /// ![file-x-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-x-duotone.svg)
   static const fileX = PhosphorDuotoneIconData(
     0xed04,
-    PhosphorIconData(0xed03, 'duotone'),
+    PhosphorIconData(0xed03, 'Duotone'),
   );
 
   /// ![file-xls-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-xls-duotone.svg)
   static const fileXls = PhosphorDuotoneIconData(
     0xed06,
-    PhosphorIconData(0xed05, 'duotone'),
+    PhosphorIconData(0xed05, 'Duotone'),
   );
 
   /// ![file-zip-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-zip-duotone.svg)
   static const fileZip = PhosphorDuotoneIconData(
     0xed08,
-    PhosphorIconData(0xed07, 'duotone'),
+    PhosphorIconData(0xed07, 'Duotone'),
   );
 
   /// ![files-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/files-duotone.svg)
   static const files = PhosphorDuotoneIconData(
     0xecf4,
-    PhosphorIconData(0xecf3, 'duotone'),
+    PhosphorIconData(0xecf3, 'Duotone'),
   );
 
   /// ![film-reel-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/film-reel-duotone.svg)
   static const filmReel = PhosphorDuotoneIconData(
     0xed0a,
-    PhosphorIconData(0xed09, 'duotone'),
+    PhosphorIconData(0xed09, 'Duotone'),
   );
 
   /// ![film-script-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/film-script-duotone.svg)
   static const filmScript = PhosphorDuotoneIconData(
     0xed0c,
-    PhosphorIconData(0xed0b, 'duotone'),
+    PhosphorIconData(0xed0b, 'Duotone'),
   );
 
   /// ![film-slate-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/film-slate-duotone.svg)
   static const filmSlate = PhosphorDuotoneIconData(
     0xed0e,
-    PhosphorIconData(0xed0d, 'duotone'),
+    PhosphorIconData(0xed0d, 'Duotone'),
   );
 
   /// ![film-strip-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/film-strip-duotone.svg)
   static const filmStrip = PhosphorDuotoneIconData(
     0xed10,
-    PhosphorIconData(0xed0f, 'duotone'),
+    PhosphorIconData(0xed0f, 'Duotone'),
   );
 
   /// ![fingerprint-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/fingerprint-duotone.svg)
   static const fingerprint = PhosphorDuotoneIconData(
     0xed12,
-    PhosphorIconData(0xed11, 'duotone'),
+    PhosphorIconData(0xed11, 'Duotone'),
   );
 
   /// ![fingerprint-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/fingerprint-simple-duotone.svg)
   static const fingerprintSimple = PhosphorDuotoneIconData(
     0xed14,
-    PhosphorIconData(0xed13, 'duotone'),
+    PhosphorIconData(0xed13, 'Duotone'),
   );
 
   /// ![finn-the-human-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/finn-the-human-duotone.svg)
   static const finnTheHuman = PhosphorDuotoneIconData(
     0xed16,
-    PhosphorIconData(0xed15, 'duotone'),
+    PhosphorIconData(0xed15, 'Duotone'),
   );
 
   /// ![fire-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/fire-duotone.svg)
   static const fire = PhosphorDuotoneIconData(
     0xed18,
-    PhosphorIconData(0xed17, 'duotone'),
+    PhosphorIconData(0xed17, 'Duotone'),
   );
 
   /// ![fire-extinguisher-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/fire-extinguisher-duotone.svg)
   static const fireExtinguisher = PhosphorDuotoneIconData(
     0xed1a,
-    PhosphorIconData(0xed19, 'duotone'),
+    PhosphorIconData(0xed19, 'Duotone'),
   );
 
   /// ![fire-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/fire-simple-duotone.svg)
   static const fireSimple = PhosphorDuotoneIconData(
     0xed1c,
-    PhosphorIconData(0xed1b, 'duotone'),
+    PhosphorIconData(0xed1b, 'Duotone'),
   );
 
   /// ![first-aid-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/first-aid-duotone.svg)
   static const firstAid = PhosphorDuotoneIconData(
     0xed1e,
-    PhosphorIconData(0xed1d, 'duotone'),
+    PhosphorIconData(0xed1d, 'Duotone'),
   );
 
   /// ![first-aid-kit-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/first-aid-kit-duotone.svg)
   static const firstAidKit = PhosphorDuotoneIconData(
     0xed20,
-    PhosphorIconData(0xed1f, 'duotone'),
+    PhosphorIconData(0xed1f, 'Duotone'),
   );
 
   /// ![fish-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/fish-duotone.svg)
   static const fish = PhosphorDuotoneIconData(
     0xed22,
-    PhosphorIconData(0xed21, 'duotone'),
+    PhosphorIconData(0xed21, 'Duotone'),
   );
 
   /// ![fish-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/fish-simple-duotone.svg)
   static const fishSimple = PhosphorDuotoneIconData(
     0xed24,
-    PhosphorIconData(0xed23, 'duotone'),
+    PhosphorIconData(0xed23, 'Duotone'),
   );
 
   /// ![flag-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/flag-duotone.svg)
   static const flag = PhosphorDuotoneIconData(
     0xed2a,
-    PhosphorIconData(0xed29, 'duotone'),
+    PhosphorIconData(0xed29, 'Duotone'),
   );
 
   /// ![flag-banner-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/flag-banner-duotone.svg)
   static const flagBanner = PhosphorDuotoneIconData(
     0xed26,
-    PhosphorIconData(0xed25, 'duotone'),
+    PhosphorIconData(0xed25, 'Duotone'),
   );
 
   /// ![flag-checkered-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/flag-checkered-duotone.svg)
   static const flagCheckered = PhosphorDuotoneIconData(
     0xed28,
-    PhosphorIconData(0xed27, 'duotone'),
+    PhosphorIconData(0xed27, 'Duotone'),
   );
 
   /// ![flag-pennant-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/flag-pennant-duotone.svg)
   static const flagPennant = PhosphorDuotoneIconData(
     0xed2c,
-    PhosphorIconData(0xed2b, 'duotone'),
+    PhosphorIconData(0xed2b, 'Duotone'),
   );
 
   /// ![flame-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/flame-duotone.svg)
   static const flame = PhosphorDuotoneIconData(
     0xed2e,
-    PhosphorIconData(0xed2d, 'duotone'),
+    PhosphorIconData(0xed2d, 'Duotone'),
   );
 
   /// ![flashlight-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/flashlight-duotone.svg)
   static const flashlight = PhosphorDuotoneIconData(
     0xed30,
-    PhosphorIconData(0xed2f, 'duotone'),
+    PhosphorIconData(0xed2f, 'Duotone'),
   );
 
   /// ![flask-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/flask-duotone.svg)
   static const flask = PhosphorDuotoneIconData(
     0xed32,
-    PhosphorIconData(0xed31, 'duotone'),
+    PhosphorIconData(0xed31, 'Duotone'),
   );
 
   /// ![floppy-disk-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/floppy-disk-duotone.svg)
   static const floppyDisk = PhosphorDuotoneIconData(
     0xed36,
-    PhosphorIconData(0xed35, 'duotone'),
+    PhosphorIconData(0xed35, 'Duotone'),
   );
 
   /// ![floppy-disk-back-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/floppy-disk-back-duotone.svg)
   static const floppyDiskBack = PhosphorDuotoneIconData(
     0xed34,
-    PhosphorIconData(0xed33, 'duotone'),
+    PhosphorIconData(0xed33, 'Duotone'),
   );
 
   /// ![flow-arrow-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/flow-arrow-duotone.svg)
   static const flowArrow = PhosphorDuotoneIconData(
     0xed38,
-    PhosphorIconData(0xed37, 'duotone'),
+    PhosphorIconData(0xed37, 'Duotone'),
   );
 
   /// ![flower-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/flower-duotone.svg)
   static const flower = PhosphorDuotoneIconData(
     0xed3a,
-    PhosphorIconData(0xed39, 'duotone'),
+    PhosphorIconData(0xed39, 'Duotone'),
   );
 
   /// ![flower-lotus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/flower-lotus-duotone.svg)
   static const flowerLotus = PhosphorDuotoneIconData(
     0xed3c,
-    PhosphorIconData(0xed3b, 'duotone'),
+    PhosphorIconData(0xed3b, 'Duotone'),
   );
 
   /// ![flower-tulip-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/flower-tulip-duotone.svg)
   static const flowerTulip = PhosphorDuotoneIconData(
     0xed3e,
-    PhosphorIconData(0xed3d, 'duotone'),
+    PhosphorIconData(0xed3d, 'Duotone'),
   );
 
   /// ![flying-saucer-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/flying-saucer-duotone.svg)
   static const flyingSaucer = PhosphorDuotoneIconData(
     0xed40,
-    PhosphorIconData(0xed3f, 'duotone'),
+    PhosphorIconData(0xed3f, 'Duotone'),
   );
 
   /// ![folder-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/folder-duotone.svg)
   static const folder = PhosphorDuotoneIconData(
     0xed44,
-    PhosphorIconData(0xed43, 'duotone'),
+    PhosphorIconData(0xed43, 'Duotone'),
   );
 
   /// ![folder-dashed-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/folder-dashed-duotone.svg)
   static const folderDashed = PhosphorDuotoneIconData(
     0xed42,
-    PhosphorIconData(0xed41, 'duotone'),
+    PhosphorIconData(0xed41, 'Duotone'),
   );
 
   /// ![folder-lock-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/folder-lock-duotone.svg)
   static const folderLock = PhosphorDuotoneIconData(
     0xed46,
-    PhosphorIconData(0xed45, 'duotone'),
+    PhosphorIconData(0xed45, 'Duotone'),
   );
 
   /// ![folder-minus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/folder-minus-duotone.svg)
   static const folderMinus = PhosphorDuotoneIconData(
     0xed48,
-    PhosphorIconData(0xed47, 'duotone'),
+    PhosphorIconData(0xed47, 'Duotone'),
   );
 
   /// ![folder-notch-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/folder-notch-duotone.svg)
   static const folderNotch = PhosphorDuotoneIconData(
     0xed4a,
-    PhosphorIconData(0xed49, 'duotone'),
+    PhosphorIconData(0xed49, 'Duotone'),
   );
 
   /// ![folder-notch-minus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/folder-notch-minus-duotone.svg)
   static const folderNotchMinus = PhosphorDuotoneIconData(
     0xed4c,
-    PhosphorIconData(0xed4b, 'duotone'),
+    PhosphorIconData(0xed4b, 'Duotone'),
   );
 
   /// ![folder-notch-open-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/folder-notch-open-duotone.svg)
   static const folderNotchOpen = PhosphorDuotoneIconData(
     0xed4e,
-    PhosphorIconData(0xed4d, 'duotone'),
+    PhosphorIconData(0xed4d, 'Duotone'),
   );
 
   /// ![folder-notch-plus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/folder-notch-plus-duotone.svg)
   static const folderNotchPlus = PhosphorDuotoneIconData(
     0xed50,
-    PhosphorIconData(0xed4f, 'duotone'),
+    PhosphorIconData(0xed4f, 'Duotone'),
   );
 
   /// ![folder-open-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/folder-open-duotone.svg)
   static const folderOpen = PhosphorDuotoneIconData(
     0xed52,
-    PhosphorIconData(0xed51, 'duotone'),
+    PhosphorIconData(0xed51, 'Duotone'),
   );
 
   /// ![folder-plus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/folder-plus-duotone.svg)
   static const folderPlus = PhosphorDuotoneIconData(
     0xed54,
-    PhosphorIconData(0xed53, 'duotone'),
+    PhosphorIconData(0xed53, 'Duotone'),
   );
 
   /// ![folder-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/folder-simple-duotone.svg)
   static const folderSimple = PhosphorDuotoneIconData(
     0xed5a,
-    PhosphorIconData(0xed59, 'duotone'),
+    PhosphorIconData(0xed59, 'Duotone'),
   );
 
   /// ![folder-simple-dashed-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/folder-simple-dashed-duotone.svg)
   static const folderSimpleDashed = PhosphorDuotoneIconData(
     0xed58,
-    PhosphorIconData(0xed57, 'duotone'),
+    PhosphorIconData(0xed57, 'Duotone'),
   );
 
   /// ![folder-simple-lock-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/folder-simple-lock-duotone.svg)
   static const folderSimpleLock = PhosphorDuotoneIconData(
     0xed5c,
-    PhosphorIconData(0xed5b, 'duotone'),
+    PhosphorIconData(0xed5b, 'Duotone'),
   );
 
   /// ![folder-simple-minus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/folder-simple-minus-duotone.svg)
   static const folderSimpleMinus = PhosphorDuotoneIconData(
     0xed5e,
-    PhosphorIconData(0xed5d, 'duotone'),
+    PhosphorIconData(0xed5d, 'Duotone'),
   );
 
   /// ![folder-simple-plus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/folder-simple-plus-duotone.svg)
   static const folderSimplePlus = PhosphorDuotoneIconData(
     0xed60,
-    PhosphorIconData(0xed5f, 'duotone'),
+    PhosphorIconData(0xed5f, 'Duotone'),
   );
 
   /// ![folder-simple-star-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/folder-simple-star-duotone.svg)
   static const folderSimpleStar = PhosphorDuotoneIconData(
     0xed62,
-    PhosphorIconData(0xed61, 'duotone'),
+    PhosphorIconData(0xed61, 'Duotone'),
   );
 
   /// ![folder-simple-user-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/folder-simple-user-duotone.svg)
   static const folderSimpleUser = PhosphorDuotoneIconData(
     0xed64,
-    PhosphorIconData(0xed63, 'duotone'),
+    PhosphorIconData(0xed63, 'Duotone'),
   );
 
   /// ![folder-star-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/folder-star-duotone.svg)
   static const folderStar = PhosphorDuotoneIconData(
     0xed66,
-    PhosphorIconData(0xed65, 'duotone'),
+    PhosphorIconData(0xed65, 'Duotone'),
   );
 
   /// ![folder-user-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/folder-user-duotone.svg)
   static const folderUser = PhosphorDuotoneIconData(
     0xed68,
-    PhosphorIconData(0xed67, 'duotone'),
+    PhosphorIconData(0xed67, 'Duotone'),
   );
 
   /// ![folders-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/folders-duotone.svg)
   static const folders = PhosphorDuotoneIconData(
     0xed56,
-    PhosphorIconData(0xed55, 'duotone'),
+    PhosphorIconData(0xed55, 'Duotone'),
   );
 
   /// ![football-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/football-duotone.svg)
   static const football = PhosphorDuotoneIconData(
     0xed6a,
-    PhosphorIconData(0xed69, 'duotone'),
+    PhosphorIconData(0xed69, 'Duotone'),
   );
 
   /// ![footprints-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/footprints-duotone.svg)
   static const footprints = PhosphorDuotoneIconData(
     0xed6c,
-    PhosphorIconData(0xed6b, 'duotone'),
+    PhosphorIconData(0xed6b, 'Duotone'),
   );
 
   /// ![fork-knife-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/fork-knife-duotone.svg)
   static const forkKnife = PhosphorDuotoneIconData(
     0xed6e,
-    PhosphorIconData(0xed6d, 'duotone'),
+    PhosphorIconData(0xed6d, 'Duotone'),
   );
 
   /// ![frame-corners-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/frame-corners-duotone.svg)
   static const frameCorners = PhosphorDuotoneIconData(
     0xed70,
-    PhosphorIconData(0xed6f, 'duotone'),
+    PhosphorIconData(0xed6f, 'Duotone'),
   );
 
   /// ![framer-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/framer-logo-duotone.svg)
   static const framerLogo = PhosphorDuotoneIconData(
     0xed72,
-    PhosphorIconData(0xed71, 'duotone'),
+    PhosphorIconData(0xed71, 'Duotone'),
   );
 
   /// ![function-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/function-duotone.svg)
   static const function = PhosphorDuotoneIconData(
     0xed74,
-    PhosphorIconData(0xed73, 'duotone'),
+    PhosphorIconData(0xed73, 'Duotone'),
   );
 
   /// ![funnel-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/funnel-duotone.svg)
   static const funnel = PhosphorDuotoneIconData(
     0xed76,
-    PhosphorIconData(0xed75, 'duotone'),
+    PhosphorIconData(0xed75, 'Duotone'),
   );
 
   /// ![funnel-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/funnel-simple-duotone.svg)
   static const funnelSimple = PhosphorDuotoneIconData(
     0xed78,
-    PhosphorIconData(0xed77, 'duotone'),
+    PhosphorIconData(0xed77, 'Duotone'),
   );
 
   /// ![game-controller-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/game-controller-duotone.svg)
   static const gameController = PhosphorDuotoneIconData(
     0xed7a,
-    PhosphorIconData(0xed79, 'duotone'),
+    PhosphorIconData(0xed79, 'Duotone'),
   );
 
   /// ![garage-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/garage-duotone.svg)
   static const garage = PhosphorDuotoneIconData(
     0xed7c,
-    PhosphorIconData(0xed7b, 'duotone'),
+    PhosphorIconData(0xed7b, 'Duotone'),
   );
 
   /// ![gas-can-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/gas-can-duotone.svg)
   static const gasCan = PhosphorDuotoneIconData(
     0xed7e,
-    PhosphorIconData(0xed7d, 'duotone'),
+    PhosphorIconData(0xed7d, 'Duotone'),
   );
 
   /// ![gas-pump-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/gas-pump-duotone.svg)
   static const gasPump = PhosphorDuotoneIconData(
     0xed80,
-    PhosphorIconData(0xed7f, 'duotone'),
+    PhosphorIconData(0xed7f, 'Duotone'),
   );
 
   /// ![gauge-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/gauge-duotone.svg)
   static const gauge = PhosphorDuotoneIconData(
     0xed82,
-    PhosphorIconData(0xed81, 'duotone'),
+    PhosphorIconData(0xed81, 'Duotone'),
   );
 
   /// ![gavel-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/gavel-duotone.svg)
   static const gavel = PhosphorDuotoneIconData(
     0xed84,
-    PhosphorIconData(0xed83, 'duotone'),
+    PhosphorIconData(0xed83, 'Duotone'),
   );
 
   /// ![gear-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/gear-duotone.svg)
   static const gear = PhosphorDuotoneIconData(
     0xed86,
-    PhosphorIconData(0xed85, 'duotone'),
+    PhosphorIconData(0xed85, 'Duotone'),
   );
 
   /// ![gear-fine-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/gear-fine-duotone.svg)
   static const gearFine = PhosphorDuotoneIconData(
     0xed88,
-    PhosphorIconData(0xed87, 'duotone'),
+    PhosphorIconData(0xed87, 'Duotone'),
   );
 
   /// ![gear-six-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/gear-six-duotone.svg)
   static const gearSix = PhosphorDuotoneIconData(
     0xed8a,
-    PhosphorIconData(0xed89, 'duotone'),
+    PhosphorIconData(0xed89, 'Duotone'),
   );
 
   /// ![gender-female-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/gender-female-duotone.svg)
   static const genderFemale = PhosphorDuotoneIconData(
     0xed8c,
-    PhosphorIconData(0xed8b, 'duotone'),
+    PhosphorIconData(0xed8b, 'Duotone'),
   );
 
   /// ![gender-intersex-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/gender-intersex-duotone.svg)
   static const genderIntersex = PhosphorDuotoneIconData(
     0xed8e,
-    PhosphorIconData(0xed8d, 'duotone'),
+    PhosphorIconData(0xed8d, 'Duotone'),
   );
 
   /// ![gender-male-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/gender-male-duotone.svg)
   static const genderMale = PhosphorDuotoneIconData(
     0xed90,
-    PhosphorIconData(0xed8f, 'duotone'),
+    PhosphorIconData(0xed8f, 'Duotone'),
   );
 
   /// ![gender-neuter-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/gender-neuter-duotone.svg)
   static const genderNeuter = PhosphorDuotoneIconData(
     0xed92,
-    PhosphorIconData(0xed91, 'duotone'),
+    PhosphorIconData(0xed91, 'Duotone'),
   );
 
   /// ![gender-nonbinary-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/gender-nonbinary-duotone.svg)
   static const genderNonbinary = PhosphorDuotoneIconData(
     0xed94,
-    PhosphorIconData(0xed93, 'duotone'),
+    PhosphorIconData(0xed93, 'Duotone'),
   );
 
   /// ![gender-transgender-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/gender-transgender-duotone.svg)
   static const genderTransgender = PhosphorDuotoneIconData(
     0xed96,
-    PhosphorIconData(0xed95, 'duotone'),
+    PhosphorIconData(0xed95, 'Duotone'),
   );
 
   /// ![ghost-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/ghost-duotone.svg)
   static const ghost = PhosphorDuotoneIconData(
     0xed98,
-    PhosphorIconData(0xed97, 'duotone'),
+    PhosphorIconData(0xed97, 'Duotone'),
   );
 
   /// ![gif-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/gif-duotone.svg)
   static const gif = PhosphorDuotoneIconData(
     0xed9a,
-    PhosphorIconData(0xed99, 'duotone'),
+    PhosphorIconData(0xed99, 'Duotone'),
   );
 
   /// ![gift-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/gift-duotone.svg)
   static const gift = PhosphorDuotoneIconData(
     0xed9c,
-    PhosphorIconData(0xed9b, 'duotone'),
+    PhosphorIconData(0xed9b, 'Duotone'),
   );
 
   /// ![git-branch-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/git-branch-duotone.svg)
   static const gitBranch = PhosphorDuotoneIconData(
     0xed9e,
-    PhosphorIconData(0xed9d, 'duotone'),
+    PhosphorIconData(0xed9d, 'Duotone'),
   );
 
   /// ![git-commit-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/git-commit-duotone.svg)
   static const gitCommit = PhosphorDuotoneIconData(
     0xeda0,
-    PhosphorIconData(0xed9f, 'duotone'),
+    PhosphorIconData(0xed9f, 'Duotone'),
   );
 
   /// ![git-diff-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/git-diff-duotone.svg)
   static const gitDiff = PhosphorDuotoneIconData(
     0xeda2,
-    PhosphorIconData(0xeda1, 'duotone'),
+    PhosphorIconData(0xeda1, 'Duotone'),
   );
 
   /// ![git-fork-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/git-fork-duotone.svg)
   static const gitFork = PhosphorDuotoneIconData(
     0xeda4,
-    PhosphorIconData(0xeda3, 'duotone'),
+    PhosphorIconData(0xeda3, 'Duotone'),
   );
 
   /// ![git-merge-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/git-merge-duotone.svg)
   static const gitMerge = PhosphorDuotoneIconData(
     0xedac,
-    PhosphorIconData(0xedab, 'duotone'),
+    PhosphorIconData(0xedab, 'Duotone'),
   );
 
   /// ![git-pull-request-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/git-pull-request-duotone.svg)
   static const gitPullRequest = PhosphorDuotoneIconData(
     0xedae,
-    PhosphorIconData(0xedad, 'duotone'),
+    PhosphorIconData(0xedad, 'Duotone'),
   );
 
   /// ![github-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/github-logo-duotone.svg)
   static const githubLogo = PhosphorDuotoneIconData(
     0xeda6,
-    PhosphorIconData(0xeda5, 'duotone'),
+    PhosphorIconData(0xeda5, 'Duotone'),
   );
 
   /// ![gitlab-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/gitlab-logo-duotone.svg)
   static const gitlabLogo = PhosphorDuotoneIconData(
     0xeda8,
-    PhosphorIconData(0xeda7, 'duotone'),
+    PhosphorIconData(0xeda7, 'Duotone'),
   );
 
   /// ![gitlab-logo-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/gitlab-logo-simple-duotone.svg)
   static const gitlabLogoSimple = PhosphorDuotoneIconData(
     0xedaa,
-    PhosphorIconData(0xeda9, 'duotone'),
+    PhosphorIconData(0xeda9, 'Duotone'),
   );
 
   /// ![globe-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/globe-duotone.svg)
   static const globe = PhosphorDuotoneIconData(
     0xedb0,
-    PhosphorIconData(0xedaf, 'duotone'),
+    PhosphorIconData(0xedaf, 'Duotone'),
   );
 
   /// ![globe-hemisphere-east-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/globe-hemisphere-east-duotone.svg)
   static const globeHemisphereEast = PhosphorDuotoneIconData(
     0xedb2,
-    PhosphorIconData(0xedb1, 'duotone'),
+    PhosphorIconData(0xedb1, 'Duotone'),
   );
 
   /// ![globe-hemisphere-west-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/globe-hemisphere-west-duotone.svg)
   static const globeHemisphereWest = PhosphorDuotoneIconData(
     0xedb4,
-    PhosphorIconData(0xedb3, 'duotone'),
+    PhosphorIconData(0xedb3, 'Duotone'),
   );
 
   /// ![globe-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/globe-simple-duotone.svg)
   static const globeSimple = PhosphorDuotoneIconData(
     0xedb6,
-    PhosphorIconData(0xedb5, 'duotone'),
+    PhosphorIconData(0xedb5, 'Duotone'),
   );
 
   /// ![globe-stand-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/globe-stand-duotone.svg)
   static const globeStand = PhosphorDuotoneIconData(
     0xedb8,
-    PhosphorIconData(0xedb7, 'duotone'),
+    PhosphorIconData(0xedb7, 'Duotone'),
   );
 
   /// ![goggles-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/goggles-duotone.svg)
   static const goggles = PhosphorDuotoneIconData(
     0xedba,
-    PhosphorIconData(0xedb9, 'duotone'),
+    PhosphorIconData(0xedb9, 'Duotone'),
   );
 
   /// ![goodreads-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/goodreads-logo-duotone.svg)
   static const goodreadsLogo = PhosphorDuotoneIconData(
     0xedbc,
-    PhosphorIconData(0xedbb, 'duotone'),
+    PhosphorIconData(0xedbb, 'Duotone'),
   );
 
   /// ![google-cardboard-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/google-cardboard-logo-duotone.svg)
   static const googleCardboardLogo = PhosphorDuotoneIconData(
     0xedbe,
-    PhosphorIconData(0xedbd, 'duotone'),
+    PhosphorIconData(0xedbd, 'Duotone'),
   );
 
   /// ![google-chrome-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/google-chrome-logo-duotone.svg)
   static const googleChromeLogo = PhosphorDuotoneIconData(
     0xedc0,
-    PhosphorIconData(0xedbf, 'duotone'),
+    PhosphorIconData(0xedbf, 'Duotone'),
   );
 
   /// ![google-drive-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/google-drive-logo-duotone.svg)
   static const googleDriveLogo = PhosphorDuotoneIconData(
     0xedc2,
-    PhosphorIconData(0xedc1, 'duotone'),
+    PhosphorIconData(0xedc1, 'Duotone'),
   );
 
   /// ![google-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/google-logo-duotone.svg)
   static const googleLogo = PhosphorDuotoneIconData(
     0xedc4,
-    PhosphorIconData(0xedc3, 'duotone'),
+    PhosphorIconData(0xedc3, 'Duotone'),
   );
 
   /// ![google-photos-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/google-photos-logo-duotone.svg)
   static const googlePhotosLogo = PhosphorDuotoneIconData(
     0xedc6,
-    PhosphorIconData(0xedc5, 'duotone'),
+    PhosphorIconData(0xedc5, 'Duotone'),
   );
 
   /// ![google-play-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/google-play-logo-duotone.svg)
   static const googlePlayLogo = PhosphorDuotoneIconData(
     0xedc8,
-    PhosphorIconData(0xedc7, 'duotone'),
+    PhosphorIconData(0xedc7, 'Duotone'),
   );
 
   /// ![google-podcasts-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/google-podcasts-logo-duotone.svg)
   static const googlePodcastsLogo = PhosphorDuotoneIconData(
     0xedca,
-    PhosphorIconData(0xedc9, 'duotone'),
+    PhosphorIconData(0xedc9, 'Duotone'),
   );
 
   /// ![gradient-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/gradient-duotone.svg)
   static const gradient = PhosphorDuotoneIconData(
     0xedcc,
-    PhosphorIconData(0xedcb, 'duotone'),
+    PhosphorIconData(0xedcb, 'Duotone'),
   );
 
   /// ![graduation-cap-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/graduation-cap-duotone.svg)
   static const graduationCap = PhosphorDuotoneIconData(
     0xedce,
-    PhosphorIconData(0xedcd, 'duotone'),
+    PhosphorIconData(0xedcd, 'Duotone'),
   );
 
   /// ![grains-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/grains-duotone.svg)
   static const grains = PhosphorDuotoneIconData(
     0xedd0,
-    PhosphorIconData(0xedcf, 'duotone'),
+    PhosphorIconData(0xedcf, 'Duotone'),
   );
 
   /// ![grains-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/grains-slash-duotone.svg)
   static const grainsSlash = PhosphorDuotoneIconData(
     0xedd2,
-    PhosphorIconData(0xedd1, 'duotone'),
+    PhosphorIconData(0xedd1, 'Duotone'),
   );
 
   /// ![graph-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/graph-duotone.svg)
   static const graph = PhosphorDuotoneIconData(
     0xedd4,
-    PhosphorIconData(0xedd3, 'duotone'),
+    PhosphorIconData(0xedd3, 'Duotone'),
   );
 
   /// ![grid-four-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/grid-four-duotone.svg)
   static const gridFour = PhosphorDuotoneIconData(
     0xedd6,
-    PhosphorIconData(0xedd5, 'duotone'),
+    PhosphorIconData(0xedd5, 'Duotone'),
   );
 
   /// ![grid-nine-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/grid-nine-duotone.svg)
   static const gridNine = PhosphorDuotoneIconData(
     0xedd8,
-    PhosphorIconData(0xedd7, 'duotone'),
+    PhosphorIconData(0xedd7, 'Duotone'),
   );
 
   /// ![guitar-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/guitar-duotone.svg)
   static const guitar = PhosphorDuotoneIconData(
     0xedda,
-    PhosphorIconData(0xedd9, 'duotone'),
+    PhosphorIconData(0xedd9, 'Duotone'),
   );
 
   /// ![hamburger-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hamburger-duotone.svg)
   static const hamburger = PhosphorDuotoneIconData(
     0xeddc,
-    PhosphorIconData(0xeddb, 'duotone'),
+    PhosphorIconData(0xeddb, 'Duotone'),
   );
 
   /// ![hammer-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hammer-duotone.svg)
   static const hammer = PhosphorDuotoneIconData(
     0xedde,
-    PhosphorIconData(0xeddd, 'duotone'),
+    PhosphorIconData(0xeddd, 'Duotone'),
   );
 
   /// ![hand-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hand-duotone.svg)
   static const hand = PhosphorDuotoneIconData(
     0xede6,
-    PhosphorIconData(0xede5, 'duotone'),
+    PhosphorIconData(0xede5, 'Duotone'),
   );
 
   /// ![hand-coins-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hand-coins-duotone.svg)
   static const handCoins = PhosphorDuotoneIconData(
     0xede4,
-    PhosphorIconData(0xede3, 'duotone'),
+    PhosphorIconData(0xede3, 'Duotone'),
   );
 
   /// ![hand-eye-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hand-eye-duotone.svg)
   static const handEye = PhosphorDuotoneIconData(
     0xede8,
-    PhosphorIconData(0xede7, 'duotone'),
+    PhosphorIconData(0xede7, 'Duotone'),
   );
 
   /// ![hand-fist-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hand-fist-duotone.svg)
   static const handFist = PhosphorDuotoneIconData(
     0xedea,
-    PhosphorIconData(0xede9, 'duotone'),
+    PhosphorIconData(0xede9, 'Duotone'),
   );
 
   /// ![hand-grabbing-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hand-grabbing-duotone.svg)
   static const handGrabbing = PhosphorDuotoneIconData(
     0xedec,
-    PhosphorIconData(0xedeb, 'duotone'),
+    PhosphorIconData(0xedeb, 'Duotone'),
   );
 
   /// ![hand-heart-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hand-heart-duotone.svg)
   static const handHeart = PhosphorDuotoneIconData(
     0xedee,
-    PhosphorIconData(0xeded, 'duotone'),
+    PhosphorIconData(0xeded, 'Duotone'),
   );
 
   /// ![hand-palm-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hand-palm-duotone.svg)
   static const handPalm = PhosphorDuotoneIconData(
     0xedf0,
-    PhosphorIconData(0xedef, 'duotone'),
+    PhosphorIconData(0xedef, 'Duotone'),
   );
 
   /// ![hand-pointing-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hand-pointing-duotone.svg)
   static const handPointing = PhosphorDuotoneIconData(
     0xedf2,
-    PhosphorIconData(0xedf1, 'duotone'),
+    PhosphorIconData(0xedf1, 'Duotone'),
   );
 
   /// ![hand-soap-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hand-soap-duotone.svg)
   static const handSoap = PhosphorDuotoneIconData(
     0xedf8,
-    PhosphorIconData(0xedf7, 'duotone'),
+    PhosphorIconData(0xedf7, 'Duotone'),
   );
 
   /// ![hand-swipe-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hand-swipe-left-duotone.svg)
   static const handSwipeLeft = PhosphorDuotoneIconData(
     0xedfc,
-    PhosphorIconData(0xedfb, 'duotone'),
+    PhosphorIconData(0xedfb, 'Duotone'),
   );
 
   /// ![hand-swipe-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hand-swipe-right-duotone.svg)
   static const handSwipeRight = PhosphorDuotoneIconData(
     0xedfe,
-    PhosphorIconData(0xedfd, 'duotone'),
+    PhosphorIconData(0xedfd, 'Duotone'),
   );
 
   /// ![hand-tap-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hand-tap-duotone.svg)
   static const handTap = PhosphorDuotoneIconData(
     0xee00,
-    PhosphorIconData(0xedff, 'duotone'),
+    PhosphorIconData(0xedff, 'Duotone'),
   );
 
   /// ![hand-waving-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hand-waving-duotone.svg)
   static const handWaving = PhosphorDuotoneIconData(
     0xee02,
-    PhosphorIconData(0xee01, 'duotone'),
+    PhosphorIconData(0xee01, 'Duotone'),
   );
 
   /// ![handbag-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/handbag-duotone.svg)
   static const handbag = PhosphorDuotoneIconData(
     0xede0,
-    PhosphorIconData(0xeddf, 'duotone'),
+    PhosphorIconData(0xeddf, 'Duotone'),
   );
 
   /// ![handbag-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/handbag-simple-duotone.svg)
   static const handbagSimple = PhosphorDuotoneIconData(
     0xede2,
-    PhosphorIconData(0xede1, 'duotone'),
+    PhosphorIconData(0xede1, 'Duotone'),
   );
 
   /// ![hands-clapping-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hands-clapping-duotone.svg)
   static const handsClapping = PhosphorDuotoneIconData(
     0xedf4,
-    PhosphorIconData(0xedf3, 'duotone'),
+    PhosphorIconData(0xedf3, 'Duotone'),
   );
 
   /// ![hands-praying-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hands-praying-duotone.svg)
   static const handsPraying = PhosphorDuotoneIconData(
     0xedfa,
-    PhosphorIconData(0xedf9, 'duotone'),
+    PhosphorIconData(0xedf9, 'Duotone'),
   );
 
   /// ![handshake-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/handshake-duotone.svg)
   static const handshake = PhosphorDuotoneIconData(
     0xedf6,
-    PhosphorIconData(0xedf5, 'duotone'),
+    PhosphorIconData(0xedf5, 'Duotone'),
   );
 
   /// ![hard-drive-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hard-drive-duotone.svg)
   static const hardDrive = PhosphorDuotoneIconData(
     0xee04,
-    PhosphorIconData(0xee03, 'duotone'),
+    PhosphorIconData(0xee03, 'Duotone'),
   );
 
   /// ![hard-drives-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hard-drives-duotone.svg)
   static const hardDrives = PhosphorDuotoneIconData(
     0xee06,
-    PhosphorIconData(0xee05, 'duotone'),
+    PhosphorIconData(0xee05, 'Duotone'),
   );
 
   /// ![hash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hash-duotone.svg)
   static const hash = PhosphorDuotoneIconData(
     0xee08,
-    PhosphorIconData(0xee07, 'duotone'),
+    PhosphorIconData(0xee07, 'Duotone'),
   );
 
   /// ![hash-straight-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hash-straight-duotone.svg)
   static const hashStraight = PhosphorDuotoneIconData(
     0xee0a,
-    PhosphorIconData(0xee09, 'duotone'),
+    PhosphorIconData(0xee09, 'Duotone'),
   );
 
   /// ![headlights-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/headlights-duotone.svg)
   static const headlights = PhosphorDuotoneIconData(
     0xee0c,
-    PhosphorIconData(0xee0b, 'duotone'),
+    PhosphorIconData(0xee0b, 'Duotone'),
   );
 
   /// ![headphones-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/headphones-duotone.svg)
   static const headphones = PhosphorDuotoneIconData(
     0xee0e,
-    PhosphorIconData(0xee0d, 'duotone'),
+    PhosphorIconData(0xee0d, 'Duotone'),
   );
 
   /// ![headset-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/headset-duotone.svg)
   static const headset = PhosphorDuotoneIconData(
     0xee10,
-    PhosphorIconData(0xee0f, 'duotone'),
+    PhosphorIconData(0xee0f, 'Duotone'),
   );
 
   /// ![heart-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/heart-duotone.svg)
   static const heart = PhosphorDuotoneIconData(
     0xee16,
-    PhosphorIconData(0xee15, 'duotone'),
+    PhosphorIconData(0xee15, 'Duotone'),
   );
 
   /// ![heart-break-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/heart-break-duotone.svg)
   static const heartBreak = PhosphorDuotoneIconData(
     0xee14,
-    PhosphorIconData(0xee13, 'duotone'),
+    PhosphorIconData(0xee13, 'Duotone'),
   );
 
   /// ![heart-half-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/heart-half-duotone.svg)
   static const heartHalf = PhosphorDuotoneIconData(
     0xee18,
-    PhosphorIconData(0xee17, 'duotone'),
+    PhosphorIconData(0xee17, 'Duotone'),
   );
 
   /// ![heart-straight-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/heart-straight-duotone.svg)
   static const heartStraight = PhosphorDuotoneIconData(
     0xee1c,
-    PhosphorIconData(0xee1b, 'duotone'),
+    PhosphorIconData(0xee1b, 'Duotone'),
   );
 
   /// ![heart-straight-break-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/heart-straight-break-duotone.svg)
   static const heartStraightBreak = PhosphorDuotoneIconData(
     0xee1a,
-    PhosphorIconData(0xee19, 'duotone'),
+    PhosphorIconData(0xee19, 'Duotone'),
   );
 
   /// ![heartbeat-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/heartbeat-duotone.svg)
   static const heartbeat = PhosphorDuotoneIconData(
     0xee12,
-    PhosphorIconData(0xee11, 'duotone'),
+    PhosphorIconData(0xee11, 'Duotone'),
   );
 
   /// ![hexagon-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hexagon-duotone.svg)
   static const hexagon = PhosphorDuotoneIconData(
     0xee1e,
-    PhosphorIconData(0xee1d, 'duotone'),
+    PhosphorIconData(0xee1d, 'Duotone'),
   );
 
   /// ![high-heel-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/high-heel-duotone.svg)
   static const highHeel = PhosphorDuotoneIconData(
     0xee20,
-    PhosphorIconData(0xee1f, 'duotone'),
+    PhosphorIconData(0xee1f, 'Duotone'),
   );
 
   /// ![highlighter-circle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/highlighter-circle-duotone.svg)
   static const highlighterCircle = PhosphorDuotoneIconData(
     0xee22,
-    PhosphorIconData(0xee21, 'duotone'),
+    PhosphorIconData(0xee21, 'Duotone'),
   );
 
   /// ![hoodie-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hoodie-duotone.svg)
   static const hoodie = PhosphorDuotoneIconData(
     0xee24,
-    PhosphorIconData(0xee23, 'duotone'),
+    PhosphorIconData(0xee23, 'Duotone'),
   );
 
   /// ![horse-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/horse-duotone.svg)
   static const horse = PhosphorDuotoneIconData(
     0xee26,
-    PhosphorIconData(0xee25, 'duotone'),
+    PhosphorIconData(0xee25, 'Duotone'),
   );
 
   /// ![hourglass-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hourglass-duotone.svg)
   static const hourglass = PhosphorDuotoneIconData(
     0xee28,
-    PhosphorIconData(0xee27, 'duotone'),
+    PhosphorIconData(0xee27, 'Duotone'),
   );
 
   /// ![hourglass-high-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hourglass-high-duotone.svg)
   static const hourglassHigh = PhosphorDuotoneIconData(
     0xee2a,
-    PhosphorIconData(0xee29, 'duotone'),
+    PhosphorIconData(0xee29, 'Duotone'),
   );
 
   /// ![hourglass-low-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hourglass-low-duotone.svg)
   static const hourglassLow = PhosphorDuotoneIconData(
     0xee2c,
-    PhosphorIconData(0xee2b, 'duotone'),
+    PhosphorIconData(0xee2b, 'Duotone'),
   );
 
   /// ![hourglass-medium-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hourglass-medium-duotone.svg)
   static const hourglassMedium = PhosphorDuotoneIconData(
     0xee2e,
-    PhosphorIconData(0xee2d, 'duotone'),
+    PhosphorIconData(0xee2d, 'Duotone'),
   );
 
   /// ![hourglass-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hourglass-simple-duotone.svg)
   static const hourglassSimple = PhosphorDuotoneIconData(
     0xee30,
-    PhosphorIconData(0xee2f, 'duotone'),
+    PhosphorIconData(0xee2f, 'Duotone'),
   );
 
   /// ![hourglass-simple-high-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hourglass-simple-high-duotone.svg)
   static const hourglassSimpleHigh = PhosphorDuotoneIconData(
     0xee32,
-    PhosphorIconData(0xee31, 'duotone'),
+    PhosphorIconData(0xee31, 'Duotone'),
   );
 
   /// ![hourglass-simple-low-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hourglass-simple-low-duotone.svg)
   static const hourglassSimpleLow = PhosphorDuotoneIconData(
     0xee34,
-    PhosphorIconData(0xee33, 'duotone'),
+    PhosphorIconData(0xee33, 'Duotone'),
   );
 
   /// ![hourglass-simple-medium-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hourglass-simple-medium-duotone.svg)
   static const hourglassSimpleMedium = PhosphorDuotoneIconData(
     0xee36,
-    PhosphorIconData(0xee35, 'duotone'),
+    PhosphorIconData(0xee35, 'Duotone'),
   );
 
   /// ![house-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/house-duotone.svg)
   static const house = PhosphorDuotoneIconData(
     0xee38,
-    PhosphorIconData(0xee37, 'duotone'),
+    PhosphorIconData(0xee37, 'Duotone'),
   );
 
   /// ![house-line-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/house-line-duotone.svg)
   static const houseLine = PhosphorDuotoneIconData(
     0xee3a,
-    PhosphorIconData(0xee39, 'duotone'),
+    PhosphorIconData(0xee39, 'Duotone'),
   );
 
   /// ![house-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/house-simple-duotone.svg)
   static const houseSimple = PhosphorDuotoneIconData(
     0xee3c,
-    PhosphorIconData(0xee3b, 'duotone'),
+    PhosphorIconData(0xee3b, 'Duotone'),
   );
 
   /// ![ice-cream-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/ice-cream-duotone.svg)
   static const iceCream = PhosphorDuotoneIconData(
     0xee3e,
-    PhosphorIconData(0xee3d, 'duotone'),
+    PhosphorIconData(0xee3d, 'Duotone'),
   );
 
   /// ![identification-badge-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/identification-badge-duotone.svg)
   static const identificationBadge = PhosphorDuotoneIconData(
     0xee40,
-    PhosphorIconData(0xee3f, 'duotone'),
+    PhosphorIconData(0xee3f, 'Duotone'),
   );
 
   /// ![identification-card-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/identification-card-duotone.svg)
   static const identificationCard = PhosphorDuotoneIconData(
     0xee42,
-    PhosphorIconData(0xee41, 'duotone'),
+    PhosphorIconData(0xee41, 'Duotone'),
   );
 
   /// ![image-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/image-duotone.svg)
   static const image = PhosphorDuotoneIconData(
     0xee44,
-    PhosphorIconData(0xee43, 'duotone'),
+    PhosphorIconData(0xee43, 'Duotone'),
   );
 
   /// ![image-square-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/image-square-duotone.svg)
   static const imageSquare = PhosphorDuotoneIconData(
     0xee48,
-    PhosphorIconData(0xee47, 'duotone'),
+    PhosphorIconData(0xee47, 'Duotone'),
   );
 
   /// ![images-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/images-duotone.svg)
   static const images = PhosphorDuotoneIconData(
     0xee46,
-    PhosphorIconData(0xee45, 'duotone'),
+    PhosphorIconData(0xee45, 'Duotone'),
   );
 
   /// ![images-square-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/images-square-duotone.svg)
   static const imagesSquare = PhosphorDuotoneIconData(
     0xee4a,
-    PhosphorIconData(0xee49, 'duotone'),
+    PhosphorIconData(0xee49, 'Duotone'),
   );
 
   /// ![infinity-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/infinity-duotone.svg)
   static const infinity = PhosphorDuotoneIconData(
     0xee4c,
-    PhosphorIconData(0xee4b, 'duotone'),
+    PhosphorIconData(0xee4b, 'Duotone'),
   );
 
   /// ![info-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/info-duotone.svg)
   static const info = PhosphorDuotoneIconData(
     0xee4e,
-    PhosphorIconData(0xee4d, 'duotone'),
+    PhosphorIconData(0xee4d, 'Duotone'),
   );
 
   /// ![instagram-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/instagram-logo-duotone.svg)
   static const instagramLogo = PhosphorDuotoneIconData(
     0xee50,
-    PhosphorIconData(0xee4f, 'duotone'),
+    PhosphorIconData(0xee4f, 'Duotone'),
   );
 
   /// ![intersect-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/intersect-duotone.svg)
   static const intersect = PhosphorDuotoneIconData(
     0xee52,
-    PhosphorIconData(0xee51, 'duotone'),
+    PhosphorIconData(0xee51, 'Duotone'),
   );
 
   /// ![intersect-square-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/intersect-square-duotone.svg)
   static const intersectSquare = PhosphorDuotoneIconData(
     0xee54,
-    PhosphorIconData(0xee53, 'duotone'),
+    PhosphorIconData(0xee53, 'Duotone'),
   );
 
   /// ![intersect-three-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/intersect-three-duotone.svg)
   static const intersectThree = PhosphorDuotoneIconData(
     0xee56,
-    PhosphorIconData(0xee55, 'duotone'),
+    PhosphorIconData(0xee55, 'Duotone'),
   );
 
   /// ![jeep-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/jeep-duotone.svg)
   static const jeep = PhosphorDuotoneIconData(
     0xee58,
-    PhosphorIconData(0xee57, 'duotone'),
+    PhosphorIconData(0xee57, 'Duotone'),
   );
 
   /// ![kanban-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/kanban-duotone.svg)
   static const kanban = PhosphorDuotoneIconData(
     0xee5a,
-    PhosphorIconData(0xee59, 'duotone'),
+    PhosphorIconData(0xee59, 'Duotone'),
   );
 
   /// ![key-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/key-duotone.svg)
   static const key = PhosphorDuotoneIconData(
     0xee5e,
-    PhosphorIconData(0xee5d, 'duotone'),
+    PhosphorIconData(0xee5d, 'Duotone'),
   );
 
   /// ![key-return-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/key-return-duotone.svg)
   static const keyReturn = PhosphorDuotoneIconData(
     0xee62,
-    PhosphorIconData(0xee61, 'duotone'),
+    PhosphorIconData(0xee61, 'Duotone'),
   );
 
   /// ![keyboard-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/keyboard-duotone.svg)
   static const keyboard = PhosphorDuotoneIconData(
     0xee5c,
-    PhosphorIconData(0xee5b, 'duotone'),
+    PhosphorIconData(0xee5b, 'Duotone'),
   );
 
   /// ![keyhole-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/keyhole-duotone.svg)
   static const keyhole = PhosphorDuotoneIconData(
     0xee60,
-    PhosphorIconData(0xee5f, 'duotone'),
+    PhosphorIconData(0xee5f, 'Duotone'),
   );
 
   /// ![knife-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/knife-duotone.svg)
   static const knife = PhosphorDuotoneIconData(
     0xee64,
-    PhosphorIconData(0xee63, 'duotone'),
+    PhosphorIconData(0xee63, 'Duotone'),
   );
 
   /// ![ladder-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/ladder-duotone.svg)
   static const ladder = PhosphorDuotoneIconData(
     0xee66,
-    PhosphorIconData(0xee65, 'duotone'),
+    PhosphorIconData(0xee65, 'Duotone'),
   );
 
   /// ![ladder-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/ladder-simple-duotone.svg)
   static const ladderSimple = PhosphorDuotoneIconData(
     0xee68,
-    PhosphorIconData(0xee67, 'duotone'),
+    PhosphorIconData(0xee67, 'Duotone'),
   );
 
   /// ![lamp-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/lamp-duotone.svg)
   static const lamp = PhosphorDuotoneIconData(
     0xee6a,
-    PhosphorIconData(0xee69, 'duotone'),
+    PhosphorIconData(0xee69, 'Duotone'),
   );
 
   /// ![laptop-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/laptop-duotone.svg)
   static const laptop = PhosphorDuotoneIconData(
     0xee6c,
-    PhosphorIconData(0xee6b, 'duotone'),
+    PhosphorIconData(0xee6b, 'Duotone'),
   );
 
   /// ![layout-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/layout-duotone.svg)
   static const layout = PhosphorDuotoneIconData(
     0xee6e,
-    PhosphorIconData(0xee6d, 'duotone'),
+    PhosphorIconData(0xee6d, 'Duotone'),
   );
 
   /// ![leaf-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/leaf-duotone.svg)
   static const leaf = PhosphorDuotoneIconData(
     0xee70,
-    PhosphorIconData(0xee6f, 'duotone'),
+    PhosphorIconData(0xee6f, 'Duotone'),
   );
 
   /// ![lifebuoy-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/lifebuoy-duotone.svg)
   static const lifebuoy = PhosphorDuotoneIconData(
     0xee72,
-    PhosphorIconData(0xee71, 'duotone'),
+    PhosphorIconData(0xee71, 'Duotone'),
   );
 
   /// ![lightbulb-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/lightbulb-duotone.svg)
   static const lightbulb = PhosphorDuotoneIconData(
     0xee74,
-    PhosphorIconData(0xee73, 'duotone'),
+    PhosphorIconData(0xee73, 'Duotone'),
   );
 
   /// ![lightbulb-filament-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/lightbulb-filament-duotone.svg)
   static const lightbulbFilament = PhosphorDuotoneIconData(
     0xee76,
-    PhosphorIconData(0xee75, 'duotone'),
+    PhosphorIconData(0xee75, 'Duotone'),
   );
 
   /// ![lighthouse-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/lighthouse-duotone.svg)
   static const lighthouse = PhosphorDuotoneIconData(
     0xee78,
-    PhosphorIconData(0xee77, 'duotone'),
+    PhosphorIconData(0xee77, 'Duotone'),
   );
 
   /// ![lightning-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/lightning-duotone.svg)
   static const lightning = PhosphorDuotoneIconData(
     0xee7c,
-    PhosphorIconData(0xee7b, 'duotone'),
+    PhosphorIconData(0xee7b, 'Duotone'),
   );
 
   /// ![lightning-a-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/lightning-a-duotone.svg)
   static const lightningA = PhosphorDuotoneIconData(
     0xee7a,
-    PhosphorIconData(0xee79, 'duotone'),
+    PhosphorIconData(0xee79, 'Duotone'),
   );
 
   /// ![lightning-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/lightning-slash-duotone.svg)
   static const lightningSlash = PhosphorDuotoneIconData(
     0xee7e,
-    PhosphorIconData(0xee7d, 'duotone'),
+    PhosphorIconData(0xee7d, 'Duotone'),
   );
 
   /// ![line-segment-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/line-segment-duotone.svg)
   static const lineSegment = PhosphorDuotoneIconData(
     0xee80,
-    PhosphorIconData(0xee7f, 'duotone'),
+    PhosphorIconData(0xee7f, 'Duotone'),
   );
 
   /// ![line-segments-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/line-segments-duotone.svg)
   static const lineSegments = PhosphorDuotoneIconData(
     0xee82,
-    PhosphorIconData(0xee81, 'duotone'),
+    PhosphorIconData(0xee81, 'Duotone'),
   );
 
   /// ![link-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/link-duotone.svg)
   static const link = PhosphorDuotoneIconData(
     0xee86,
-    PhosphorIconData(0xee85, 'duotone'),
+    PhosphorIconData(0xee85, 'Duotone'),
   );
 
   /// ![link-break-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/link-break-duotone.svg)
   static const linkBreak = PhosphorDuotoneIconData(
     0xee84,
-    PhosphorIconData(0xee83, 'duotone'),
+    PhosphorIconData(0xee83, 'Duotone'),
   );
 
   /// ![link-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/link-simple-duotone.svg)
   static const linkSimple = PhosphorDuotoneIconData(
     0xee8c,
-    PhosphorIconData(0xee8b, 'duotone'),
+    PhosphorIconData(0xee8b, 'Duotone'),
   );
 
   /// ![link-simple-break-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/link-simple-break-duotone.svg)
   static const linkSimpleBreak = PhosphorDuotoneIconData(
     0xee8a,
-    PhosphorIconData(0xee89, 'duotone'),
+    PhosphorIconData(0xee89, 'Duotone'),
   );
 
   /// ![link-simple-horizontal-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/link-simple-horizontal-duotone.svg)
   static const linkSimpleHorizontal = PhosphorDuotoneIconData(
     0xee90,
-    PhosphorIconData(0xee8f, 'duotone'),
+    PhosphorIconData(0xee8f, 'Duotone'),
   );
 
   /// ![link-simple-horizontal-break-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/link-simple-horizontal-break-duotone.svg)
   static const linkSimpleHorizontalBreak = PhosphorDuotoneIconData(
     0xee8e,
-    PhosphorIconData(0xee8d, 'duotone'),
+    PhosphorIconData(0xee8d, 'Duotone'),
   );
 
   /// ![linkedin-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/linkedin-logo-duotone.svg)
   static const linkedinLogo = PhosphorDuotoneIconData(
     0xee88,
-    PhosphorIconData(0xee87, 'duotone'),
+    PhosphorIconData(0xee87, 'Duotone'),
   );
 
   /// ![linux-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/linux-logo-duotone.svg)
   static const linuxLogo = PhosphorDuotoneIconData(
     0xee92,
-    PhosphorIconData(0xee91, 'duotone'),
+    PhosphorIconData(0xee91, 'Duotone'),
   );
 
   /// ![list-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/list-duotone.svg)
   static const list = PhosphorDuotoneIconData(
     0xee9a,
-    PhosphorIconData(0xee99, 'duotone'),
+    PhosphorIconData(0xee99, 'Duotone'),
   );
 
   /// ![list-bullets-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/list-bullets-duotone.svg)
   static const listBullets = PhosphorDuotoneIconData(
     0xee94,
-    PhosphorIconData(0xee93, 'duotone'),
+    PhosphorIconData(0xee93, 'Duotone'),
   );
 
   /// ![list-checks-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/list-checks-duotone.svg)
   static const listChecks = PhosphorDuotoneIconData(
     0xee96,
-    PhosphorIconData(0xee95, 'duotone'),
+    PhosphorIconData(0xee95, 'Duotone'),
   );
 
   /// ![list-dashes-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/list-dashes-duotone.svg)
   static const listDashes = PhosphorDuotoneIconData(
     0xee98,
-    PhosphorIconData(0xee97, 'duotone'),
+    PhosphorIconData(0xee97, 'Duotone'),
   );
 
   /// ![list-magnifying-glass-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/list-magnifying-glass-duotone.svg)
   static const listMagnifyingGlass = PhosphorDuotoneIconData(
     0xee9c,
-    PhosphorIconData(0xee9b, 'duotone'),
+    PhosphorIconData(0xee9b, 'Duotone'),
   );
 
   /// ![list-numbers-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/list-numbers-duotone.svg)
   static const listNumbers = PhosphorDuotoneIconData(
     0xee9e,
-    PhosphorIconData(0xee9d, 'duotone'),
+    PhosphorIconData(0xee9d, 'Duotone'),
   );
 
   /// ![list-plus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/list-plus-duotone.svg)
   static const listPlus = PhosphorDuotoneIconData(
     0xeea0,
-    PhosphorIconData(0xee9f, 'duotone'),
+    PhosphorIconData(0xee9f, 'Duotone'),
   );
 
   /// ![lock-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/lock-duotone.svg)
   static const lock = PhosphorDuotoneIconData(
     0xeea2,
-    PhosphorIconData(0xeea1, 'duotone'),
+    PhosphorIconData(0xeea1, 'Duotone'),
   );
 
   /// ![lock-key-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/lock-key-duotone.svg)
   static const lockKey = PhosphorDuotoneIconData(
     0xeea6,
-    PhosphorIconData(0xeea5, 'duotone'),
+    PhosphorIconData(0xeea5, 'Duotone'),
   );
 
   /// ![lock-key-open-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/lock-key-open-duotone.svg)
   static const lockKeyOpen = PhosphorDuotoneIconData(
     0xeea8,
-    PhosphorIconData(0xeea7, 'duotone'),
+    PhosphorIconData(0xeea7, 'Duotone'),
   );
 
   /// ![lock-laminated-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/lock-laminated-duotone.svg)
   static const lockLaminated = PhosphorDuotoneIconData(
     0xeeaa,
-    PhosphorIconData(0xeea9, 'duotone'),
+    PhosphorIconData(0xeea9, 'Duotone'),
   );
 
   /// ![lock-laminated-open-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/lock-laminated-open-duotone.svg)
   static const lockLaminatedOpen = PhosphorDuotoneIconData(
     0xeeac,
-    PhosphorIconData(0xeeab, 'duotone'),
+    PhosphorIconData(0xeeab, 'Duotone'),
   );
 
   /// ![lock-open-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/lock-open-duotone.svg)
   static const lockOpen = PhosphorDuotoneIconData(
     0xeeae,
-    PhosphorIconData(0xeead, 'duotone'),
+    PhosphorIconData(0xeead, 'Duotone'),
   );
 
   /// ![lock-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/lock-simple-duotone.svg)
   static const lockSimple = PhosphorDuotoneIconData(
     0xeeb0,
-    PhosphorIconData(0xeeaf, 'duotone'),
+    PhosphorIconData(0xeeaf, 'Duotone'),
   );
 
   /// ![lock-simple-open-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/lock-simple-open-duotone.svg)
   static const lockSimpleOpen = PhosphorDuotoneIconData(
     0xeeb2,
-    PhosphorIconData(0xeeb1, 'duotone'),
+    PhosphorIconData(0xeeb1, 'Duotone'),
   );
 
   /// ![lockers-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/lockers-duotone.svg)
   static const lockers = PhosphorDuotoneIconData(
     0xeea4,
-    PhosphorIconData(0xeea3, 'duotone'),
+    PhosphorIconData(0xeea3, 'Duotone'),
   );
 
   /// ![magic-wand-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/magic-wand-duotone.svg)
   static const magicWand = PhosphorDuotoneIconData(
     0xeeb4,
-    PhosphorIconData(0xeeb3, 'duotone'),
+    PhosphorIconData(0xeeb3, 'Duotone'),
   );
 
   /// ![magnet-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/magnet-duotone.svg)
   static const magnet = PhosphorDuotoneIconData(
     0xeeb6,
-    PhosphorIconData(0xeeb5, 'duotone'),
+    PhosphorIconData(0xeeb5, 'Duotone'),
   );
 
   /// ![magnet-straight-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/magnet-straight-duotone.svg)
   static const magnetStraight = PhosphorDuotoneIconData(
     0xeeb8,
-    PhosphorIconData(0xeeb7, 'duotone'),
+    PhosphorIconData(0xeeb7, 'Duotone'),
   );
 
   /// ![magnifying-glass-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/magnifying-glass-duotone.svg)
   static const magnifyingGlass = PhosphorDuotoneIconData(
     0xeeba,
-    PhosphorIconData(0xeeb9, 'duotone'),
+    PhosphorIconData(0xeeb9, 'Duotone'),
   );
 
   /// ![magnifying-glass-minus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/magnifying-glass-minus-duotone.svg)
   static const magnifyingGlassMinus = PhosphorDuotoneIconData(
     0xeebc,
-    PhosphorIconData(0xeebb, 'duotone'),
+    PhosphorIconData(0xeebb, 'Duotone'),
   );
 
   /// ![magnifying-glass-plus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/magnifying-glass-plus-duotone.svg)
   static const magnifyingGlassPlus = PhosphorDuotoneIconData(
     0xeebe,
-    PhosphorIconData(0xeebd, 'duotone'),
+    PhosphorIconData(0xeebd, 'Duotone'),
   );
 
   /// ![map-pin-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/map-pin-duotone.svg)
   static const mapPin = PhosphorDuotoneIconData(
     0xeec0,
-    PhosphorIconData(0xeebf, 'duotone'),
+    PhosphorIconData(0xeebf, 'Duotone'),
   );
 
   /// ![map-pin-line-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/map-pin-line-duotone.svg)
   static const mapPinLine = PhosphorDuotoneIconData(
     0xeec2,
-    PhosphorIconData(0xeec1, 'duotone'),
+    PhosphorIconData(0xeec1, 'Duotone'),
   );
 
   /// ![map-trifold-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/map-trifold-duotone.svg)
   static const mapTrifold = PhosphorDuotoneIconData(
     0xeec4,
-    PhosphorIconData(0xeec3, 'duotone'),
+    PhosphorIconData(0xeec3, 'Duotone'),
   );
 
   /// ![marker-circle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/marker-circle-duotone.svg)
   static const markerCircle = PhosphorDuotoneIconData(
     0xeec6,
-    PhosphorIconData(0xeec5, 'duotone'),
+    PhosphorIconData(0xeec5, 'Duotone'),
   );
 
   /// ![martini-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/martini-duotone.svg)
   static const martini = PhosphorDuotoneIconData(
     0xeec8,
-    PhosphorIconData(0xeec7, 'duotone'),
+    PhosphorIconData(0xeec7, 'Duotone'),
   );
 
   /// ![mask-happy-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/mask-happy-duotone.svg)
   static const maskHappy = PhosphorDuotoneIconData(
     0xeeca,
-    PhosphorIconData(0xeec9, 'duotone'),
+    PhosphorIconData(0xeec9, 'Duotone'),
   );
 
   /// ![mask-sad-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/mask-sad-duotone.svg)
   static const maskSad = PhosphorDuotoneIconData(
     0xeecc,
-    PhosphorIconData(0xeecb, 'duotone'),
+    PhosphorIconData(0xeecb, 'Duotone'),
   );
 
   /// ![math-operations-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/math-operations-duotone.svg)
   static const mathOperations = PhosphorDuotoneIconData(
     0xeece,
-    PhosphorIconData(0xeecd, 'duotone'),
+    PhosphorIconData(0xeecd, 'Duotone'),
   );
 
   /// ![medal-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/medal-duotone.svg)
   static const medal = PhosphorDuotoneIconData(
     0xeed0,
-    PhosphorIconData(0xeecf, 'duotone'),
+    PhosphorIconData(0xeecf, 'Duotone'),
   );
 
   /// ![medal-military-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/medal-military-duotone.svg)
   static const medalMilitary = PhosphorDuotoneIconData(
     0xeed2,
-    PhosphorIconData(0xeed1, 'duotone'),
+    PhosphorIconData(0xeed1, 'Duotone'),
   );
 
   /// ![medium-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/medium-logo-duotone.svg)
   static const mediumLogo = PhosphorDuotoneIconData(
     0xeed4,
-    PhosphorIconData(0xeed3, 'duotone'),
+    PhosphorIconData(0xeed3, 'Duotone'),
   );
 
   /// ![megaphone-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/megaphone-duotone.svg)
   static const megaphone = PhosphorDuotoneIconData(
     0xeed6,
-    PhosphorIconData(0xeed5, 'duotone'),
+    PhosphorIconData(0xeed5, 'Duotone'),
   );
 
   /// ![megaphone-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/megaphone-simple-duotone.svg)
   static const megaphoneSimple = PhosphorDuotoneIconData(
     0xeed8,
-    PhosphorIconData(0xeed7, 'duotone'),
+    PhosphorIconData(0xeed7, 'Duotone'),
   );
 
   /// ![messenger-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/messenger-logo-duotone.svg)
   static const messengerLogo = PhosphorDuotoneIconData(
     0xeeda,
-    PhosphorIconData(0xeed9, 'duotone'),
+    PhosphorIconData(0xeed9, 'Duotone'),
   );
 
   /// ![meta-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/meta-logo-duotone.svg)
   static const metaLogo = PhosphorDuotoneIconData(
     0xeedc,
-    PhosphorIconData(0xeedb, 'duotone'),
+    PhosphorIconData(0xeedb, 'Duotone'),
   );
 
   /// ![metronome-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/metronome-duotone.svg)
   static const metronome = PhosphorDuotoneIconData(
     0xeede,
-    PhosphorIconData(0xeedd, 'duotone'),
+    PhosphorIconData(0xeedd, 'Duotone'),
   );
 
   /// ![microphone-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/microphone-duotone.svg)
   static const microphone = PhosphorDuotoneIconData(
     0xeee0,
-    PhosphorIconData(0xeedf, 'duotone'),
+    PhosphorIconData(0xeedf, 'Duotone'),
   );
 
   /// ![microphone-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/microphone-slash-duotone.svg)
   static const microphoneSlash = PhosphorDuotoneIconData(
     0xeee2,
-    PhosphorIconData(0xeee1, 'duotone'),
+    PhosphorIconData(0xeee1, 'Duotone'),
   );
 
   /// ![microphone-stage-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/microphone-stage-duotone.svg)
   static const microphoneStage = PhosphorDuotoneIconData(
     0xeee4,
-    PhosphorIconData(0xeee3, 'duotone'),
+    PhosphorIconData(0xeee3, 'Duotone'),
   );
 
   /// ![microsoft-excel-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/microsoft-excel-logo-duotone.svg)
   static const microsoftExcelLogo = PhosphorDuotoneIconData(
     0xeee6,
-    PhosphorIconData(0xeee5, 'duotone'),
+    PhosphorIconData(0xeee5, 'Duotone'),
   );
 
   /// ![microsoft-outlook-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/microsoft-outlook-logo-duotone.svg)
   static const microsoftOutlookLogo = PhosphorDuotoneIconData(
     0xeee8,
-    PhosphorIconData(0xeee7, 'duotone'),
+    PhosphorIconData(0xeee7, 'Duotone'),
   );
 
   /// ![microsoft-powerpoint-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/microsoft-powerpoint-logo-duotone.svg)
   static const microsoftPowerpointLogo = PhosphorDuotoneIconData(
     0xeeea,
-    PhosphorIconData(0xeee9, 'duotone'),
+    PhosphorIconData(0xeee9, 'Duotone'),
   );
 
   /// ![microsoft-teams-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/microsoft-teams-logo-duotone.svg)
   static const microsoftTeamsLogo = PhosphorDuotoneIconData(
     0xeeec,
-    PhosphorIconData(0xeeeb, 'duotone'),
+    PhosphorIconData(0xeeeb, 'Duotone'),
   );
 
   /// ![microsoft-word-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/microsoft-word-logo-duotone.svg)
   static const microsoftWordLogo = PhosphorDuotoneIconData(
     0xeeee,
-    PhosphorIconData(0xeeed, 'duotone'),
+    PhosphorIconData(0xeeed, 'Duotone'),
   );
 
   /// ![minus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/minus-duotone.svg)
   static const minus = PhosphorDuotoneIconData(
     0xeef2,
-    PhosphorIconData(0xeef1, 'duotone'),
+    PhosphorIconData(0xeef1, 'Duotone'),
   );
 
   /// ![minus-circle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/minus-circle-duotone.svg)
   static const minusCircle = PhosphorDuotoneIconData(
     0xeef0,
-    PhosphorIconData(0xeeef, 'duotone'),
+    PhosphorIconData(0xeeef, 'Duotone'),
   );
 
   /// ![minus-square-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/minus-square-duotone.svg)
   static const minusSquare = PhosphorDuotoneIconData(
     0xeef4,
-    PhosphorIconData(0xeef3, 'duotone'),
+    PhosphorIconData(0xeef3, 'Duotone'),
   );
 
   /// ![money-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/money-duotone.svg)
   static const money = PhosphorDuotoneIconData(
     0xeef6,
-    PhosphorIconData(0xeef5, 'duotone'),
+    PhosphorIconData(0xeef5, 'Duotone'),
   );
 
   /// ![monitor-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/monitor-duotone.svg)
   static const monitor = PhosphorDuotoneIconData(
     0xeef8,
-    PhosphorIconData(0xeef7, 'duotone'),
+    PhosphorIconData(0xeef7, 'Duotone'),
   );
 
   /// ![monitor-play-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/monitor-play-duotone.svg)
   static const monitorPlay = PhosphorDuotoneIconData(
     0xeefa,
-    PhosphorIconData(0xeef9, 'duotone'),
+    PhosphorIconData(0xeef9, 'Duotone'),
   );
 
   /// ![moon-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/moon-duotone.svg)
   static const moon = PhosphorDuotoneIconData(
     0xeefc,
-    PhosphorIconData(0xeefb, 'duotone'),
+    PhosphorIconData(0xeefb, 'Duotone'),
   );
 
   /// ![moon-stars-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/moon-stars-duotone.svg)
   static const moonStars = PhosphorDuotoneIconData(
     0xeefe,
-    PhosphorIconData(0xeefd, 'duotone'),
+    PhosphorIconData(0xeefd, 'Duotone'),
   );
 
   /// ![moped-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/moped-duotone.svg)
   static const moped = PhosphorDuotoneIconData(
     0xef00,
-    PhosphorIconData(0xeeff, 'duotone'),
+    PhosphorIconData(0xeeff, 'Duotone'),
   );
 
   /// ![moped-front-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/moped-front-duotone.svg)
   static const mopedFront = PhosphorDuotoneIconData(
     0xef02,
-    PhosphorIconData(0xef01, 'duotone'),
+    PhosphorIconData(0xef01, 'Duotone'),
   );
 
   /// ![mosque-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/mosque-duotone.svg)
   static const mosque = PhosphorDuotoneIconData(
     0xef04,
-    PhosphorIconData(0xef03, 'duotone'),
+    PhosphorIconData(0xef03, 'Duotone'),
   );
 
   /// ![motorcycle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/motorcycle-duotone.svg)
   static const motorcycle = PhosphorDuotoneIconData(
     0xef06,
-    PhosphorIconData(0xef05, 'duotone'),
+    PhosphorIconData(0xef05, 'Duotone'),
   );
 
   /// ![mountains-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/mountains-duotone.svg)
   static const mountains = PhosphorDuotoneIconData(
     0xef08,
-    PhosphorIconData(0xef07, 'duotone'),
+    PhosphorIconData(0xef07, 'Duotone'),
   );
 
   /// ![mouse-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/mouse-duotone.svg)
   static const mouse = PhosphorDuotoneIconData(
     0xef0a,
-    PhosphorIconData(0xef09, 'duotone'),
+    PhosphorIconData(0xef09, 'Duotone'),
   );
 
   /// ![mouse-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/mouse-simple-duotone.svg)
   static const mouseSimple = PhosphorDuotoneIconData(
     0xef0c,
-    PhosphorIconData(0xef0b, 'duotone'),
+    PhosphorIconData(0xef0b, 'Duotone'),
   );
 
   /// ![music-note-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/music-note-duotone.svg)
   static const musicNote = PhosphorDuotoneIconData(
     0xef0e,
-    PhosphorIconData(0xef0d, 'duotone'),
+    PhosphorIconData(0xef0d, 'Duotone'),
   );
 
   /// ![music-note-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/music-note-simple-duotone.svg)
   static const musicNoteSimple = PhosphorDuotoneIconData(
     0xef12,
-    PhosphorIconData(0xef11, 'duotone'),
+    PhosphorIconData(0xef11, 'Duotone'),
   );
 
   /// ![music-notes-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/music-notes-duotone.svg)
   static const musicNotes = PhosphorDuotoneIconData(
     0xef10,
-    PhosphorIconData(0xef0f, 'duotone'),
+    PhosphorIconData(0xef0f, 'Duotone'),
   );
 
   /// ![music-notes-plus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/music-notes-plus-duotone.svg)
   static const musicNotesPlus = PhosphorDuotoneIconData(
     0xef14,
-    PhosphorIconData(0xef13, 'duotone'),
+    PhosphorIconData(0xef13, 'Duotone'),
   );
 
   /// ![music-notes-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/music-notes-simple-duotone.svg)
   static const musicNotesSimple = PhosphorDuotoneIconData(
     0xef16,
-    PhosphorIconData(0xef15, 'duotone'),
+    PhosphorIconData(0xef15, 'Duotone'),
   );
 
   /// ![navigation-arrow-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/navigation-arrow-duotone.svg)
   static const navigationArrow = PhosphorDuotoneIconData(
     0xef18,
-    PhosphorIconData(0xef17, 'duotone'),
+    PhosphorIconData(0xef17, 'Duotone'),
   );
 
   /// ![needle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/needle-duotone.svg)
   static const needle = PhosphorDuotoneIconData(
     0xef1a,
-    PhosphorIconData(0xef19, 'duotone'),
+    PhosphorIconData(0xef19, 'Duotone'),
   );
 
   /// ![newspaper-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/newspaper-duotone.svg)
   static const newspaper = PhosphorDuotoneIconData(
     0xef1e,
-    PhosphorIconData(0xef1d, 'duotone'),
+    PhosphorIconData(0xef1d, 'Duotone'),
   );
 
   /// ![newspaper-clipping-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/newspaper-clipping-duotone.svg)
   static const newspaperClipping = PhosphorDuotoneIconData(
     0xef1c,
-    PhosphorIconData(0xef1b, 'duotone'),
+    PhosphorIconData(0xef1b, 'Duotone'),
   );
 
   /// ![notches-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/notches-duotone.svg)
   static const notches = PhosphorDuotoneIconData(
     0xef20,
-    PhosphorIconData(0xef1f, 'duotone'),
+    PhosphorIconData(0xef1f, 'Duotone'),
   );
 
   /// ![note-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/note-duotone.svg)
   static const note = PhosphorDuotoneIconData(
     0xef26,
-    PhosphorIconData(0xef25, 'duotone'),
+    PhosphorIconData(0xef25, 'Duotone'),
   );
 
   /// ![note-blank-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/note-blank-duotone.svg)
   static const noteBlank = PhosphorDuotoneIconData(
     0xef22,
-    PhosphorIconData(0xef21, 'duotone'),
+    PhosphorIconData(0xef21, 'Duotone'),
   );
 
   /// ![note-pencil-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/note-pencil-duotone.svg)
   static const notePencil = PhosphorDuotoneIconData(
     0xef2a,
-    PhosphorIconData(0xef29, 'duotone'),
+    PhosphorIconData(0xef29, 'Duotone'),
   );
 
   /// ![notebook-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/notebook-duotone.svg)
   static const notebook = PhosphorDuotoneIconData(
     0xef24,
-    PhosphorIconData(0xef23, 'duotone'),
+    PhosphorIconData(0xef23, 'Duotone'),
   );
 
   /// ![notepad-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/notepad-duotone.svg)
   static const notepad = PhosphorDuotoneIconData(
     0xef28,
-    PhosphorIconData(0xef27, 'duotone'),
+    PhosphorIconData(0xef27, 'Duotone'),
   );
 
   /// ![notification-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/notification-duotone.svg)
   static const notification = PhosphorDuotoneIconData(
     0xef2c,
-    PhosphorIconData(0xef2b, 'duotone'),
+    PhosphorIconData(0xef2b, 'Duotone'),
   );
 
   /// ![notion-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/notion-logo-duotone.svg)
   static const notionLogo = PhosphorDuotoneIconData(
     0xef2e,
-    PhosphorIconData(0xef2d, 'duotone'),
+    PhosphorIconData(0xef2d, 'Duotone'),
   );
 
   /// ![number-circle-eight-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-circle-eight-duotone.svg)
   static const numberCircleEight = PhosphorDuotoneIconData(
     0xef30,
-    PhosphorIconData(0xef2f, 'duotone'),
+    PhosphorIconData(0xef2f, 'Duotone'),
   );
 
   /// ![number-circle-five-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-circle-five-duotone.svg)
   static const numberCircleFive = PhosphorDuotoneIconData(
     0xef32,
-    PhosphorIconData(0xef31, 'duotone'),
+    PhosphorIconData(0xef31, 'Duotone'),
   );
 
   /// ![number-circle-four-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-circle-four-duotone.svg)
   static const numberCircleFour = PhosphorDuotoneIconData(
     0xef34,
-    PhosphorIconData(0xef33, 'duotone'),
+    PhosphorIconData(0xef33, 'Duotone'),
   );
 
   /// ![number-circle-nine-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-circle-nine-duotone.svg)
   static const numberCircleNine = PhosphorDuotoneIconData(
     0xef36,
-    PhosphorIconData(0xef35, 'duotone'),
+    PhosphorIconData(0xef35, 'Duotone'),
   );
 
   /// ![number-circle-one-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-circle-one-duotone.svg)
   static const numberCircleOne = PhosphorDuotoneIconData(
     0xef38,
-    PhosphorIconData(0xef37, 'duotone'),
+    PhosphorIconData(0xef37, 'Duotone'),
   );
 
   /// ![number-circle-seven-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-circle-seven-duotone.svg)
   static const numberCircleSeven = PhosphorDuotoneIconData(
     0xef3a,
-    PhosphorIconData(0xef39, 'duotone'),
+    PhosphorIconData(0xef39, 'Duotone'),
   );
 
   /// ![number-circle-six-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-circle-six-duotone.svg)
   static const numberCircleSix = PhosphorDuotoneIconData(
     0xef3c,
-    PhosphorIconData(0xef3b, 'duotone'),
+    PhosphorIconData(0xef3b, 'Duotone'),
   );
 
   /// ![number-circle-three-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-circle-three-duotone.svg)
   static const numberCircleThree = PhosphorDuotoneIconData(
     0xef3e,
-    PhosphorIconData(0xef3d, 'duotone'),
+    PhosphorIconData(0xef3d, 'Duotone'),
   );
 
   /// ![number-circle-two-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-circle-two-duotone.svg)
   static const numberCircleTwo = PhosphorDuotoneIconData(
     0xef40,
-    PhosphorIconData(0xef3f, 'duotone'),
+    PhosphorIconData(0xef3f, 'Duotone'),
   );
 
   /// ![number-circle-zero-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-circle-zero-duotone.svg)
   static const numberCircleZero = PhosphorDuotoneIconData(
     0xef42,
-    PhosphorIconData(0xef41, 'duotone'),
+    PhosphorIconData(0xef41, 'Duotone'),
   );
 
   /// ![number-eight-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-eight-duotone.svg)
   static const numberEight = PhosphorDuotoneIconData(
     0xef44,
-    PhosphorIconData(0xef43, 'duotone'),
+    PhosphorIconData(0xef43, 'Duotone'),
   );
 
   /// ![number-five-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-five-duotone.svg)
   static const numberFive = PhosphorDuotoneIconData(
     0xef46,
-    PhosphorIconData(0xef45, 'duotone'),
+    PhosphorIconData(0xef45, 'Duotone'),
   );
 
   /// ![number-four-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-four-duotone.svg)
   static const numberFour = PhosphorDuotoneIconData(
     0xef48,
-    PhosphorIconData(0xef47, 'duotone'),
+    PhosphorIconData(0xef47, 'Duotone'),
   );
 
   /// ![number-nine-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-nine-duotone.svg)
   static const numberNine = PhosphorDuotoneIconData(
     0xef4a,
-    PhosphorIconData(0xef49, 'duotone'),
+    PhosphorIconData(0xef49, 'Duotone'),
   );
 
   /// ![number-one-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-one-duotone.svg)
   static const numberOne = PhosphorDuotoneIconData(
     0xef4c,
-    PhosphorIconData(0xef4b, 'duotone'),
+    PhosphorIconData(0xef4b, 'Duotone'),
   );
 
   /// ![number-seven-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-seven-duotone.svg)
   static const numberSeven = PhosphorDuotoneIconData(
     0xef4e,
-    PhosphorIconData(0xef4d, 'duotone'),
+    PhosphorIconData(0xef4d, 'Duotone'),
   );
 
   /// ![number-six-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-six-duotone.svg)
   static const numberSix = PhosphorDuotoneIconData(
     0xef50,
-    PhosphorIconData(0xef4f, 'duotone'),
+    PhosphorIconData(0xef4f, 'Duotone'),
   );
 
   /// ![number-square-eight-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-square-eight-duotone.svg)
   static const numberSquareEight = PhosphorDuotoneIconData(
     0xef52,
-    PhosphorIconData(0xef51, 'duotone'),
+    PhosphorIconData(0xef51, 'Duotone'),
   );
 
   /// ![number-square-five-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-square-five-duotone.svg)
   static const numberSquareFive = PhosphorDuotoneIconData(
     0xef54,
-    PhosphorIconData(0xef53, 'duotone'),
+    PhosphorIconData(0xef53, 'Duotone'),
   );
 
   /// ![number-square-four-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-square-four-duotone.svg)
   static const numberSquareFour = PhosphorDuotoneIconData(
     0xef56,
-    PhosphorIconData(0xef55, 'duotone'),
+    PhosphorIconData(0xef55, 'Duotone'),
   );
 
   /// ![number-square-nine-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-square-nine-duotone.svg)
   static const numberSquareNine = PhosphorDuotoneIconData(
     0xef58,
-    PhosphorIconData(0xef57, 'duotone'),
+    PhosphorIconData(0xef57, 'Duotone'),
   );
 
   /// ![number-square-one-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-square-one-duotone.svg)
   static const numberSquareOne = PhosphorDuotoneIconData(
     0xef5a,
-    PhosphorIconData(0xef59, 'duotone'),
+    PhosphorIconData(0xef59, 'Duotone'),
   );
 
   /// ![number-square-seven-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-square-seven-duotone.svg)
   static const numberSquareSeven = PhosphorDuotoneIconData(
     0xef5c,
-    PhosphorIconData(0xef5b, 'duotone'),
+    PhosphorIconData(0xef5b, 'Duotone'),
   );
 
   /// ![number-square-six-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-square-six-duotone.svg)
   static const numberSquareSix = PhosphorDuotoneIconData(
     0xef5e,
-    PhosphorIconData(0xef5d, 'duotone'),
+    PhosphorIconData(0xef5d, 'Duotone'),
   );
 
   /// ![number-square-three-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-square-three-duotone.svg)
   static const numberSquareThree = PhosphorDuotoneIconData(
     0xef60,
-    PhosphorIconData(0xef5f, 'duotone'),
+    PhosphorIconData(0xef5f, 'Duotone'),
   );
 
   /// ![number-square-two-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-square-two-duotone.svg)
   static const numberSquareTwo = PhosphorDuotoneIconData(
     0xef62,
-    PhosphorIconData(0xef61, 'duotone'),
+    PhosphorIconData(0xef61, 'Duotone'),
   );
 
   /// ![number-square-zero-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-square-zero-duotone.svg)
   static const numberSquareZero = PhosphorDuotoneIconData(
     0xef64,
-    PhosphorIconData(0xef63, 'duotone'),
+    PhosphorIconData(0xef63, 'Duotone'),
   );
 
   /// ![number-three-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-three-duotone.svg)
   static const numberThree = PhosphorDuotoneIconData(
     0xef66,
-    PhosphorIconData(0xef65, 'duotone'),
+    PhosphorIconData(0xef65, 'Duotone'),
   );
 
   /// ![number-two-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-two-duotone.svg)
   static const numberTwo = PhosphorDuotoneIconData(
     0xef68,
-    PhosphorIconData(0xef67, 'duotone'),
+    PhosphorIconData(0xef67, 'Duotone'),
   );
 
   /// ![number-zero-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-zero-duotone.svg)
   static const numberZero = PhosphorDuotoneIconData(
     0xef6a,
-    PhosphorIconData(0xef69, 'duotone'),
+    PhosphorIconData(0xef69, 'Duotone'),
   );
 
   /// ![nut-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/nut-duotone.svg)
   static const nut = PhosphorDuotoneIconData(
     0xef6c,
-    PhosphorIconData(0xef6b, 'duotone'),
+    PhosphorIconData(0xef6b, 'Duotone'),
   );
 
   /// ![ny-times-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/ny-times-logo-duotone.svg)
   static const nyTimesLogo = PhosphorDuotoneIconData(
     0xef6e,
-    PhosphorIconData(0xef6d, 'duotone'),
+    PhosphorIconData(0xef6d, 'Duotone'),
   );
 
   /// ![octagon-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/octagon-duotone.svg)
   static const octagon = PhosphorDuotoneIconData(
     0xef70,
-    PhosphorIconData(0xef6f, 'duotone'),
+    PhosphorIconData(0xef6f, 'Duotone'),
   );
 
   /// ![office-chair-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/office-chair-duotone.svg)
   static const officeChair = PhosphorDuotoneIconData(
     0xef72,
-    PhosphorIconData(0xef71, 'duotone'),
+    PhosphorIconData(0xef71, 'Duotone'),
   );
 
   /// ![option-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/option-duotone.svg)
   static const option = PhosphorDuotoneIconData(
     0xef74,
-    PhosphorIconData(0xef73, 'duotone'),
+    PhosphorIconData(0xef73, 'Duotone'),
   );
 
   /// ![orange-slice-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/orange-slice-duotone.svg)
   static const orangeSlice = PhosphorDuotoneIconData(
     0xef76,
-    PhosphorIconData(0xef75, 'duotone'),
+    PhosphorIconData(0xef75, 'Duotone'),
   );
 
   /// ![package-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/package-duotone.svg)
   static const package = PhosphorDuotoneIconData(
     0xef78,
-    PhosphorIconData(0xef77, 'duotone'),
+    PhosphorIconData(0xef77, 'Duotone'),
   );
 
   /// ![paint-brush-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/paint-brush-duotone.svg)
   static const paintBrush = PhosphorDuotoneIconData(
     0xef7c,
-    PhosphorIconData(0xef7b, 'duotone'),
+    PhosphorIconData(0xef7b, 'Duotone'),
   );
 
   /// ![paint-brush-broad-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/paint-brush-broad-duotone.svg)
   static const paintBrushBroad = PhosphorDuotoneIconData(
     0xef7a,
-    PhosphorIconData(0xef79, 'duotone'),
+    PhosphorIconData(0xef79, 'Duotone'),
   );
 
   /// ![paint-brush-household-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/paint-brush-household-duotone.svg)
   static const paintBrushHousehold = PhosphorDuotoneIconData(
     0xef7e,
-    PhosphorIconData(0xef7d, 'duotone'),
+    PhosphorIconData(0xef7d, 'Duotone'),
   );
 
   /// ![paint-bucket-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/paint-bucket-duotone.svg)
   static const paintBucket = PhosphorDuotoneIconData(
     0xef80,
-    PhosphorIconData(0xef7f, 'duotone'),
+    PhosphorIconData(0xef7f, 'Duotone'),
   );
 
   /// ![paint-roller-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/paint-roller-duotone.svg)
   static const paintRoller = PhosphorDuotoneIconData(
     0xef82,
-    PhosphorIconData(0xef81, 'duotone'),
+    PhosphorIconData(0xef81, 'Duotone'),
   );
 
   /// ![palette-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/palette-duotone.svg)
   static const palette = PhosphorDuotoneIconData(
     0xef84,
-    PhosphorIconData(0xef83, 'duotone'),
+    PhosphorIconData(0xef83, 'Duotone'),
   );
 
   /// ![pants-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/pants-duotone.svg)
   static const pants = PhosphorDuotoneIconData(
     0xef86,
-    PhosphorIconData(0xef85, 'duotone'),
+    PhosphorIconData(0xef85, 'Duotone'),
   );
 
   /// ![paper-plane-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/paper-plane-duotone.svg)
   static const paperPlane = PhosphorDuotoneIconData(
     0xef8c,
-    PhosphorIconData(0xef8b, 'duotone'),
+    PhosphorIconData(0xef8b, 'Duotone'),
   );
 
   /// ![paper-plane-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/paper-plane-right-duotone.svg)
   static const paperPlaneRight = PhosphorDuotoneIconData(
     0xef8e,
-    PhosphorIconData(0xef8d, 'duotone'),
+    PhosphorIconData(0xef8d, 'Duotone'),
   );
 
   /// ![paper-plane-tilt-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/paper-plane-tilt-duotone.svg)
   static const paperPlaneTilt = PhosphorDuotoneIconData(
     0xef90,
-    PhosphorIconData(0xef8f, 'duotone'),
+    PhosphorIconData(0xef8f, 'Duotone'),
   );
 
   /// ![paperclip-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/paperclip-duotone.svg)
   static const paperclip = PhosphorDuotoneIconData(
     0xef88,
-    PhosphorIconData(0xef87, 'duotone'),
+    PhosphorIconData(0xef87, 'Duotone'),
   );
 
   /// ![paperclip-horizontal-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/paperclip-horizontal-duotone.svg)
   static const paperclipHorizontal = PhosphorDuotoneIconData(
     0xef8a,
-    PhosphorIconData(0xef89, 'duotone'),
+    PhosphorIconData(0xef89, 'Duotone'),
   );
 
   /// ![parachute-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/parachute-duotone.svg)
   static const parachute = PhosphorDuotoneIconData(
     0xef92,
-    PhosphorIconData(0xef91, 'duotone'),
+    PhosphorIconData(0xef91, 'Duotone'),
   );
 
   /// ![paragraph-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/paragraph-duotone.svg)
   static const paragraph = PhosphorDuotoneIconData(
     0xef94,
-    PhosphorIconData(0xef93, 'duotone'),
+    PhosphorIconData(0xef93, 'Duotone'),
   );
 
   /// ![parallelogram-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/parallelogram-duotone.svg)
   static const parallelogram = PhosphorDuotoneIconData(
     0xef96,
-    PhosphorIconData(0xef95, 'duotone'),
+    PhosphorIconData(0xef95, 'Duotone'),
   );
 
   /// ![park-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/park-duotone.svg)
   static const park = PhosphorDuotoneIconData(
     0xef98,
-    PhosphorIconData(0xef97, 'duotone'),
+    PhosphorIconData(0xef97, 'Duotone'),
   );
 
   /// ![password-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/password-duotone.svg)
   static const password = PhosphorDuotoneIconData(
     0xef9a,
-    PhosphorIconData(0xef99, 'duotone'),
+    PhosphorIconData(0xef99, 'Duotone'),
   );
 
   /// ![path-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/path-duotone.svg)
   static const path = PhosphorDuotoneIconData(
     0xef9c,
-    PhosphorIconData(0xef9b, 'duotone'),
+    PhosphorIconData(0xef9b, 'Duotone'),
   );
 
   /// ![patreon-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/patreon-logo-duotone.svg)
   static const patreonLogo = PhosphorDuotoneIconData(
     0xef9e,
-    PhosphorIconData(0xef9d, 'duotone'),
+    PhosphorIconData(0xef9d, 'Duotone'),
   );
 
   /// ![pause-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/pause-duotone.svg)
   static const pause = PhosphorDuotoneIconData(
     0xefa2,
-    PhosphorIconData(0xefa1, 'duotone'),
+    PhosphorIconData(0xefa1, 'Duotone'),
   );
 
   /// ![pause-circle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/pause-circle-duotone.svg)
   static const pauseCircle = PhosphorDuotoneIconData(
     0xefa0,
-    PhosphorIconData(0xef9f, 'duotone'),
+    PhosphorIconData(0xef9f, 'Duotone'),
   );
 
   /// ![paw-print-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/paw-print-duotone.svg)
   static const pawPrint = PhosphorDuotoneIconData(
     0xefa4,
-    PhosphorIconData(0xefa3, 'duotone'),
+    PhosphorIconData(0xefa3, 'Duotone'),
   );
 
   /// ![paypal-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/paypal-logo-duotone.svg)
   static const paypalLogo = PhosphorDuotoneIconData(
     0xefa6,
-    PhosphorIconData(0xefa5, 'duotone'),
+    PhosphorIconData(0xefa5, 'Duotone'),
   );
 
   /// ![peace-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/peace-duotone.svg)
   static const peace = PhosphorDuotoneIconData(
     0xefa8,
-    PhosphorIconData(0xefa7, 'duotone'),
+    PhosphorIconData(0xefa7, 'Duotone'),
   );
 
   /// ![pen-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/pen-duotone.svg)
   static const pen = PhosphorDuotoneIconData(
     0xefb8,
-    PhosphorIconData(0xefb7, 'duotone'),
+    PhosphorIconData(0xefb7, 'Duotone'),
   );
 
   /// ![pen-nib-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/pen-nib-duotone.svg)
   static const penNib = PhosphorDuotoneIconData(
     0xefba,
-    PhosphorIconData(0xefb9, 'duotone'),
+    PhosphorIconData(0xefb9, 'Duotone'),
   );
 
   /// ![pen-nib-straight-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/pen-nib-straight-duotone.svg)
   static const penNibStraight = PhosphorDuotoneIconData(
     0xefbc,
-    PhosphorIconData(0xefbb, 'duotone'),
+    PhosphorIconData(0xefbb, 'Duotone'),
   );
 
   /// ![pencil-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/pencil-duotone.svg)
   static const pencil = PhosphorDuotoneIconData(
     0xefac,
-    PhosphorIconData(0xefab, 'duotone'),
+    PhosphorIconData(0xefab, 'Duotone'),
   );
 
   /// ![pencil-circle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/pencil-circle-duotone.svg)
   static const pencilCircle = PhosphorDuotoneIconData(
     0xefaa,
-    PhosphorIconData(0xefa9, 'duotone'),
+    PhosphorIconData(0xefa9, 'Duotone'),
   );
 
   /// ![pencil-line-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/pencil-line-duotone.svg)
   static const pencilLine = PhosphorDuotoneIconData(
     0xefae,
-    PhosphorIconData(0xefad, 'duotone'),
+    PhosphorIconData(0xefad, 'Duotone'),
   );
 
   /// ![pencil-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/pencil-simple-duotone.svg)
   static const pencilSimple = PhosphorDuotoneIconData(
     0xefb0,
-    PhosphorIconData(0xefaf, 'duotone'),
+    PhosphorIconData(0xefaf, 'Duotone'),
   );
 
   /// ![pencil-simple-line-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/pencil-simple-line-duotone.svg)
   static const pencilSimpleLine = PhosphorDuotoneIconData(
     0xefb2,
-    PhosphorIconData(0xefb1, 'duotone'),
+    PhosphorIconData(0xefb1, 'Duotone'),
   );
 
   /// ![pencil-simple-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/pencil-simple-slash-duotone.svg)
   static const pencilSimpleSlash = PhosphorDuotoneIconData(
     0xefb4,
-    PhosphorIconData(0xefb3, 'duotone'),
+    PhosphorIconData(0xefb3, 'Duotone'),
   );
 
   /// ![pencil-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/pencil-slash-duotone.svg)
   static const pencilSlash = PhosphorDuotoneIconData(
     0xefb6,
-    PhosphorIconData(0xefb5, 'duotone'),
+    PhosphorIconData(0xefb5, 'Duotone'),
   );
 
   /// ![pentagram-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/pentagram-duotone.svg)
   static const pentagram = PhosphorDuotoneIconData(
     0xefbe,
-    PhosphorIconData(0xefbd, 'duotone'),
+    PhosphorIconData(0xefbd, 'Duotone'),
   );
 
   /// ![pepper-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/pepper-duotone.svg)
   static const pepper = PhosphorDuotoneIconData(
     0xefc0,
-    PhosphorIconData(0xefbf, 'duotone'),
+    PhosphorIconData(0xefbf, 'Duotone'),
   );
 
   /// ![percent-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/percent-duotone.svg)
   static const percent = PhosphorDuotoneIconData(
     0xefc2,
-    PhosphorIconData(0xefc1, 'duotone'),
+    PhosphorIconData(0xefc1, 'Duotone'),
   );
 
   /// ![person-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/person-duotone.svg)
   static const person = PhosphorDuotoneIconData(
     0xefc6,
-    PhosphorIconData(0xefc5, 'duotone'),
+    PhosphorIconData(0xefc5, 'Duotone'),
   );
 
   /// ![person-arms-spread-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/person-arms-spread-duotone.svg)
   static const personArmsSpread = PhosphorDuotoneIconData(
     0xefc4,
-    PhosphorIconData(0xefc3, 'duotone'),
+    PhosphorIconData(0xefc3, 'Duotone'),
   );
 
   /// ![person-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/person-simple-duotone.svg)
   static const personSimple = PhosphorDuotoneIconData(
     0xefca,
-    PhosphorIconData(0xefc9, 'duotone'),
+    PhosphorIconData(0xefc9, 'Duotone'),
   );
 
   /// ![person-simple-bike-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/person-simple-bike-duotone.svg)
   static const personSimpleBike = PhosphorDuotoneIconData(
     0xefc8,
-    PhosphorIconData(0xefc7, 'duotone'),
+    PhosphorIconData(0xefc7, 'Duotone'),
   );
 
   /// ![person-simple-run-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/person-simple-run-duotone.svg)
   static const personSimpleRun = PhosphorDuotoneIconData(
     0xefcc,
-    PhosphorIconData(0xefcb, 'duotone'),
+    PhosphorIconData(0xefcb, 'Duotone'),
   );
 
   /// ![person-simple-throw-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/person-simple-throw-duotone.svg)
   static const personSimpleThrow = PhosphorDuotoneIconData(
     0xefce,
-    PhosphorIconData(0xefcd, 'duotone'),
+    PhosphorIconData(0xefcd, 'Duotone'),
   );
 
   /// ![person-simple-walk-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/person-simple-walk-duotone.svg)
   static const personSimpleWalk = PhosphorDuotoneIconData(
     0xefd0,
-    PhosphorIconData(0xefcf, 'duotone'),
+    PhosphorIconData(0xefcf, 'Duotone'),
   );
 
   /// ![perspective-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/perspective-duotone.svg)
   static const perspective = PhosphorDuotoneIconData(
     0xefd2,
-    PhosphorIconData(0xefd1, 'duotone'),
+    PhosphorIconData(0xefd1, 'Duotone'),
   );
 
   /// ![phone-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/phone-duotone.svg)
   static const phone = PhosphorDuotoneIconData(
     0xefd8,
-    PhosphorIconData(0xefd7, 'duotone'),
+    PhosphorIconData(0xefd7, 'Duotone'),
   );
 
   /// ![phone-call-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/phone-call-duotone.svg)
   static const phoneCall = PhosphorDuotoneIconData(
     0xefd4,
-    PhosphorIconData(0xefd3, 'duotone'),
+    PhosphorIconData(0xefd3, 'Duotone'),
   );
 
   /// ![phone-disconnect-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/phone-disconnect-duotone.svg)
   static const phoneDisconnect = PhosphorDuotoneIconData(
     0xefd6,
-    PhosphorIconData(0xefd5, 'duotone'),
+    PhosphorIconData(0xefd5, 'Duotone'),
   );
 
   /// ![phone-incoming-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/phone-incoming-duotone.svg)
   static const phoneIncoming = PhosphorDuotoneIconData(
     0xefda,
-    PhosphorIconData(0xefd9, 'duotone'),
+    PhosphorIconData(0xefd9, 'Duotone'),
   );
 
   /// ![phone-outgoing-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/phone-outgoing-duotone.svg)
   static const phoneOutgoing = PhosphorDuotoneIconData(
     0xefdc,
-    PhosphorIconData(0xefdb, 'duotone'),
+    PhosphorIconData(0xefdb, 'Duotone'),
   );
 
   /// ![phone-plus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/phone-plus-duotone.svg)
   static const phonePlus = PhosphorDuotoneIconData(
     0xefde,
-    PhosphorIconData(0xefdd, 'duotone'),
+    PhosphorIconData(0xefdd, 'Duotone'),
   );
 
   /// ![phone-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/phone-slash-duotone.svg)
   static const phoneSlash = PhosphorDuotoneIconData(
     0xefe0,
-    PhosphorIconData(0xefdf, 'duotone'),
+    PhosphorIconData(0xefdf, 'Duotone'),
   );
 
   /// ![phone-x-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/phone-x-duotone.svg)
   static const phoneX = PhosphorDuotoneIconData(
     0xefe2,
-    PhosphorIconData(0xefe1, 'duotone'),
+    PhosphorIconData(0xefe1, 'Duotone'),
   );
 
   /// ![phosphor-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/phosphor-logo-duotone.svg)
   static const phosphorLogo = PhosphorDuotoneIconData(
     0xefe4,
-    PhosphorIconData(0xefe3, 'duotone'),
+    PhosphorIconData(0xefe3, 'Duotone'),
   );
 
   /// ![pi-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/pi-duotone.svg)
   static const pi = PhosphorDuotoneIconData(
     0xefea,
-    PhosphorIconData(0xefe9, 'duotone'),
+    PhosphorIconData(0xefe9, 'Duotone'),
   );
 
   /// ![piano-keys-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/piano-keys-duotone.svg)
   static const pianoKeys = PhosphorDuotoneIconData(
     0xefe6,
-    PhosphorIconData(0xefe5, 'duotone'),
+    PhosphorIconData(0xefe5, 'Duotone'),
   );
 
   /// ![picture-in-picture-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/picture-in-picture-duotone.svg)
   static const pictureInpicture = PhosphorDuotoneIconData(
     0xefe8,
-    PhosphorIconData(0xefe7, 'duotone'),
+    PhosphorIconData(0xefe7, 'Duotone'),
   );
 
   /// ![piggy-bank-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/piggy-bank-duotone.svg)
   static const piggyBank = PhosphorDuotoneIconData(
     0xefec,
-    PhosphorIconData(0xefeb, 'duotone'),
+    PhosphorIconData(0xefeb, 'Duotone'),
   );
 
   /// ![pill-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/pill-duotone.svg)
   static const pill = PhosphorDuotoneIconData(
     0xefee,
-    PhosphorIconData(0xefed, 'duotone'),
+    PhosphorIconData(0xefed, 'Duotone'),
   );
 
   /// ![pinterest-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/pinterest-logo-duotone.svg)
   static const pinterestLogo = PhosphorDuotoneIconData(
     0xeff0,
-    PhosphorIconData(0xefef, 'duotone'),
+    PhosphorIconData(0xefef, 'Duotone'),
   );
 
   /// ![pinwheel-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/pinwheel-duotone.svg)
   static const pinwheel = PhosphorDuotoneIconData(
     0xeff2,
-    PhosphorIconData(0xeff1, 'duotone'),
+    PhosphorIconData(0xeff1, 'Duotone'),
   );
 
   /// ![pizza-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/pizza-duotone.svg)
   static const pizza = PhosphorDuotoneIconData(
     0xeff4,
-    PhosphorIconData(0xeff3, 'duotone'),
+    PhosphorIconData(0xeff3, 'Duotone'),
   );
 
   /// ![placeholder-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/placeholder-duotone.svg)
   static const placeholder = PhosphorDuotoneIconData(
     0xeff6,
-    PhosphorIconData(0xeff5, 'duotone'),
+    PhosphorIconData(0xeff5, 'Duotone'),
   );
 
   /// ![planet-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/planet-duotone.svg)
   static const planet = PhosphorDuotoneIconData(
     0xeff8,
-    PhosphorIconData(0xeff7, 'duotone'),
+    PhosphorIconData(0xeff7, 'Duotone'),
   );
 
   /// ![plant-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/plant-duotone.svg)
   static const plant = PhosphorDuotoneIconData(
     0xeffa,
-    PhosphorIconData(0xeff9, 'duotone'),
+    PhosphorIconData(0xeff9, 'Duotone'),
   );
 
   /// ![play-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/play-duotone.svg)
   static const play = PhosphorDuotoneIconData(
     0xeffe,
-    PhosphorIconData(0xeffd, 'duotone'),
+    PhosphorIconData(0xeffd, 'Duotone'),
   );
 
   /// ![play-circle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/play-circle-duotone.svg)
   static const playCircle = PhosphorDuotoneIconData(
     0xeffc,
-    PhosphorIconData(0xeffb, 'duotone'),
+    PhosphorIconData(0xeffb, 'Duotone'),
   );
 
   /// ![play-pause-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/play-pause-duotone.svg)
   static const playPause = PhosphorDuotoneIconData(
     0xf002,
-    PhosphorIconData(0xf001, 'duotone'),
+    PhosphorIconData(0xf001, 'Duotone'),
   );
 
   /// ![playlist-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/playlist-duotone.svg)
   static const playlist = PhosphorDuotoneIconData(
     0xf000,
-    PhosphorIconData(0xefff, 'duotone'),
+    PhosphorIconData(0xefff, 'Duotone'),
   );
 
   /// ![plug-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/plug-duotone.svg)
   static const plug = PhosphorDuotoneIconData(
     0xf006,
-    PhosphorIconData(0xf005, 'duotone'),
+    PhosphorIconData(0xf005, 'Duotone'),
   );
 
   /// ![plug-charging-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/plug-charging-duotone.svg)
   static const plugCharging = PhosphorDuotoneIconData(
     0xf004,
-    PhosphorIconData(0xf003, 'duotone'),
+    PhosphorIconData(0xf003, 'Duotone'),
   );
 
   /// ![plugs-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/plugs-duotone.svg)
   static const plugs = PhosphorDuotoneIconData(
     0xf00a,
-    PhosphorIconData(0xf009, 'duotone'),
+    PhosphorIconData(0xf009, 'Duotone'),
   );
 
   /// ![plugs-connected-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/plugs-connected-duotone.svg)
   static const plugsConnected = PhosphorDuotoneIconData(
     0xf008,
-    PhosphorIconData(0xf007, 'duotone'),
+    PhosphorIconData(0xf007, 'Duotone'),
   );
 
   /// ![plus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/plus-duotone.svg)
   static const plus = PhosphorDuotoneIconData(
     0xf00e,
-    PhosphorIconData(0xf00d, 'duotone'),
+    PhosphorIconData(0xf00d, 'Duotone'),
   );
 
   /// ![plus-circle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/plus-circle-duotone.svg)
   static const plusCircle = PhosphorDuotoneIconData(
     0xf00c,
-    PhosphorIconData(0xf00b, 'duotone'),
+    PhosphorIconData(0xf00b, 'Duotone'),
   );
 
   /// ![plus-minus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/plus-minus-duotone.svg)
   static const plusMinus = PhosphorDuotoneIconData(
     0xf010,
-    PhosphorIconData(0xf00f, 'duotone'),
+    PhosphorIconData(0xf00f, 'Duotone'),
   );
 
   /// ![plus-square-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/plus-square-duotone.svg)
   static const plusSquare = PhosphorDuotoneIconData(
     0xf012,
-    PhosphorIconData(0xf011, 'duotone'),
+    PhosphorIconData(0xf011, 'Duotone'),
   );
 
   /// ![poker-chip-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/poker-chip-duotone.svg)
   static const pokerChip = PhosphorDuotoneIconData(
     0xf014,
-    PhosphorIconData(0xf013, 'duotone'),
+    PhosphorIconData(0xf013, 'Duotone'),
   );
 
   /// ![police-car-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/police-car-duotone.svg)
   static const policeCar = PhosphorDuotoneIconData(
     0xf016,
-    PhosphorIconData(0xf015, 'duotone'),
+    PhosphorIconData(0xf015, 'Duotone'),
   );
 
   /// ![polygon-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/polygon-duotone.svg)
   static const polygon = PhosphorDuotoneIconData(
     0xf018,
-    PhosphorIconData(0xf017, 'duotone'),
+    PhosphorIconData(0xf017, 'Duotone'),
   );
 
   /// ![popcorn-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/popcorn-duotone.svg)
   static const popcorn = PhosphorDuotoneIconData(
     0xf01a,
-    PhosphorIconData(0xf019, 'duotone'),
+    PhosphorIconData(0xf019, 'Duotone'),
   );
 
   /// ![potted-plant-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/potted-plant-duotone.svg)
   static const pottedPlant = PhosphorDuotoneIconData(
     0xf01c,
-    PhosphorIconData(0xf01b, 'duotone'),
+    PhosphorIconData(0xf01b, 'Duotone'),
   );
 
   /// ![power-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/power-duotone.svg)
   static const power = PhosphorDuotoneIconData(
     0xf01e,
-    PhosphorIconData(0xf01d, 'duotone'),
+    PhosphorIconData(0xf01d, 'Duotone'),
   );
 
   /// ![prescription-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/prescription-duotone.svg)
   static const prescription = PhosphorDuotoneIconData(
     0xf020,
-    PhosphorIconData(0xf01f, 'duotone'),
+    PhosphorIconData(0xf01f, 'Duotone'),
   );
 
   /// ![presentation-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/presentation-duotone.svg)
   static const presentation = PhosphorDuotoneIconData(
     0xf024,
-    PhosphorIconData(0xf023, 'duotone'),
+    PhosphorIconData(0xf023, 'Duotone'),
   );
 
   /// ![presentation-chart-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/presentation-chart-duotone.svg)
   static const presentationChart = PhosphorDuotoneIconData(
     0xf022,
-    PhosphorIconData(0xf021, 'duotone'),
+    PhosphorIconData(0xf021, 'Duotone'),
   );
 
   /// ![printer-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/printer-duotone.svg)
   static const printer = PhosphorDuotoneIconData(
     0xf026,
-    PhosphorIconData(0xf025, 'duotone'),
+    PhosphorIconData(0xf025, 'Duotone'),
   );
 
   /// ![prohibit-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/prohibit-duotone.svg)
   static const prohibit = PhosphorDuotoneIconData(
     0xf028,
-    PhosphorIconData(0xf027, 'duotone'),
+    PhosphorIconData(0xf027, 'Duotone'),
   );
 
   /// ![prohibit-inset-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/prohibit-inset-duotone.svg)
   static const prohibitInset = PhosphorDuotoneIconData(
     0xf02a,
-    PhosphorIconData(0xf029, 'duotone'),
+    PhosphorIconData(0xf029, 'Duotone'),
   );
 
   /// ![projector-screen-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/projector-screen-duotone.svg)
   static const projectorScreen = PhosphorDuotoneIconData(
     0xf02e,
-    PhosphorIconData(0xf02d, 'duotone'),
+    PhosphorIconData(0xf02d, 'Duotone'),
   );
 
   /// ![projector-screen-chart-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/projector-screen-chart-duotone.svg)
   static const projectorScreenChart = PhosphorDuotoneIconData(
     0xf02c,
-    PhosphorIconData(0xf02b, 'duotone'),
+    PhosphorIconData(0xf02b, 'Duotone'),
   );
 
   /// ![pulse-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/pulse-duotone.svg)
   static const pulse = PhosphorDuotoneIconData(
     0xf030,
-    PhosphorIconData(0xf02f, 'duotone'),
+    PhosphorIconData(0xf02f, 'Duotone'),
   );
 
   /// ![push-pin-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/push-pin-duotone.svg)
   static const pushPin = PhosphorDuotoneIconData(
     0xf032,
-    PhosphorIconData(0xf031, 'duotone'),
+    PhosphorIconData(0xf031, 'Duotone'),
   );
 
   /// ![push-pin-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/push-pin-simple-duotone.svg)
   static const pushPinSimple = PhosphorDuotoneIconData(
     0xf034,
-    PhosphorIconData(0xf033, 'duotone'),
+    PhosphorIconData(0xf033, 'Duotone'),
   );
 
   /// ![push-pin-simple-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/push-pin-simple-slash-duotone.svg)
   static const pushPinSimpleSlash = PhosphorDuotoneIconData(
     0xf036,
-    PhosphorIconData(0xf035, 'duotone'),
+    PhosphorIconData(0xf035, 'Duotone'),
   );
 
   /// ![push-pin-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/push-pin-slash-duotone.svg)
   static const pushPinSlash = PhosphorDuotoneIconData(
     0xf038,
-    PhosphorIconData(0xf037, 'duotone'),
+    PhosphorIconData(0xf037, 'Duotone'),
   );
 
   /// ![puzzle-piece-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/puzzle-piece-duotone.svg)
   static const puzzlePiece = PhosphorDuotoneIconData(
     0xf03a,
-    PhosphorIconData(0xf039, 'duotone'),
+    PhosphorIconData(0xf039, 'Duotone'),
   );
 
   /// ![qr-code-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/qr-code-duotone.svg)
   static const qrCode = PhosphorDuotoneIconData(
     0xf03c,
-    PhosphorIconData(0xf03b, 'duotone'),
+    PhosphorIconData(0xf03b, 'Duotone'),
   );
 
   /// ![question-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/question-duotone.svg)
   static const question = PhosphorDuotoneIconData(
     0xf03e,
-    PhosphorIconData(0xf03d, 'duotone'),
+    PhosphorIconData(0xf03d, 'Duotone'),
   );
 
   /// ![queue-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/queue-duotone.svg)
   static const queue = PhosphorDuotoneIconData(
     0xf040,
-    PhosphorIconData(0xf03f, 'duotone'),
+    PhosphorIconData(0xf03f, 'Duotone'),
   );
 
   /// ![quotes-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/quotes-duotone.svg)
   static const quotes = PhosphorDuotoneIconData(
     0xf042,
-    PhosphorIconData(0xf041, 'duotone'),
+    PhosphorIconData(0xf041, 'Duotone'),
   );
 
   /// ![radical-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/radical-duotone.svg)
   static const radical = PhosphorDuotoneIconData(
     0xf044,
-    PhosphorIconData(0xf043, 'duotone'),
+    PhosphorIconData(0xf043, 'Duotone'),
   );
 
   /// ![radio-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/radio-duotone.svg)
   static const radio = PhosphorDuotoneIconData(
     0xf04a,
-    PhosphorIconData(0xf049, 'duotone'),
+    PhosphorIconData(0xf049, 'Duotone'),
   );
 
   /// ![radio-button-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/radio-button-duotone.svg)
   static const radioButton = PhosphorDuotoneIconData(
     0xf048,
-    PhosphorIconData(0xf047, 'duotone'),
+    PhosphorIconData(0xf047, 'Duotone'),
   );
 
   /// ![radioactive-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/radioactive-duotone.svg)
   static const radioactive = PhosphorDuotoneIconData(
     0xf046,
-    PhosphorIconData(0xf045, 'duotone'),
+    PhosphorIconData(0xf045, 'Duotone'),
   );
 
   /// ![rainbow-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/rainbow-duotone.svg)
   static const rainbow = PhosphorDuotoneIconData(
     0xf04e,
-    PhosphorIconData(0xf04d, 'duotone'),
+    PhosphorIconData(0xf04d, 'Duotone'),
   );
 
   /// ![rainbow-cloud-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/rainbow-cloud-duotone.svg)
   static const rainbowCloud = PhosphorDuotoneIconData(
     0xf04c,
-    PhosphorIconData(0xf04b, 'duotone'),
+    PhosphorIconData(0xf04b, 'Duotone'),
   );
 
   /// ![read-cv-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/read-cv-logo-duotone.svg)
   static const readCvLogo = PhosphorDuotoneIconData(
     0xf050,
-    PhosphorIconData(0xf04f, 'duotone'),
+    PhosphorIconData(0xf04f, 'Duotone'),
   );
 
   /// ![receipt-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/receipt-duotone.svg)
   static const receipt = PhosphorDuotoneIconData(
     0xf052,
-    PhosphorIconData(0xf051, 'duotone'),
+    PhosphorIconData(0xf051, 'Duotone'),
   );
 
   /// ![receipt-x-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/receipt-x-duotone.svg)
   static const receiptX = PhosphorDuotoneIconData(
     0xf054,
-    PhosphorIconData(0xf053, 'duotone'),
+    PhosphorIconData(0xf053, 'Duotone'),
   );
 
   /// ![record-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/record-duotone.svg)
   static const record = PhosphorDuotoneIconData(
     0xf056,
-    PhosphorIconData(0xf055, 'duotone'),
+    PhosphorIconData(0xf055, 'Duotone'),
   );
 
   /// ![rectangle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/rectangle-duotone.svg)
   static const rectangle = PhosphorDuotoneIconData(
     0xf058,
-    PhosphorIconData(0xf057, 'duotone'),
+    PhosphorIconData(0xf057, 'Duotone'),
   );
 
   /// ![recycle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/recycle-duotone.svg)
   static const recycle = PhosphorDuotoneIconData(
     0xf05a,
-    PhosphorIconData(0xf059, 'duotone'),
+    PhosphorIconData(0xf059, 'Duotone'),
   );
 
   /// ![reddit-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/reddit-logo-duotone.svg)
   static const redditLogo = PhosphorDuotoneIconData(
     0xf05c,
-    PhosphorIconData(0xf05b, 'duotone'),
+    PhosphorIconData(0xf05b, 'Duotone'),
   );
 
   /// ![repeat-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/repeat-duotone.svg)
   static const repeat = PhosphorDuotoneIconData(
     0xf05e,
-    PhosphorIconData(0xf05d, 'duotone'),
+    PhosphorIconData(0xf05d, 'Duotone'),
   );
 
   /// ![repeat-once-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/repeat-once-duotone.svg)
   static const repeatOnce = PhosphorDuotoneIconData(
     0xf060,
-    PhosphorIconData(0xf05f, 'duotone'),
+    PhosphorIconData(0xf05f, 'Duotone'),
   );
 
   /// ![rewind-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/rewind-duotone.svg)
   static const rewind = PhosphorDuotoneIconData(
     0xf064,
-    PhosphorIconData(0xf063, 'duotone'),
+    PhosphorIconData(0xf063, 'Duotone'),
   );
 
   /// ![rewind-circle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/rewind-circle-duotone.svg)
   static const rewindCircle = PhosphorDuotoneIconData(
     0xf062,
-    PhosphorIconData(0xf061, 'duotone'),
+    PhosphorIconData(0xf061, 'Duotone'),
   );
 
   /// ![road-horizon-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/road-horizon-duotone.svg)
   static const roadHorizon = PhosphorDuotoneIconData(
     0xf066,
-    PhosphorIconData(0xf065, 'duotone'),
+    PhosphorIconData(0xf065, 'Duotone'),
   );
 
   /// ![robot-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/robot-duotone.svg)
   static const robot = PhosphorDuotoneIconData(
     0xf068,
-    PhosphorIconData(0xf067, 'duotone'),
+    PhosphorIconData(0xf067, 'Duotone'),
   );
 
   /// ![rocket-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/rocket-duotone.svg)
   static const rocket = PhosphorDuotoneIconData(
     0xf06a,
-    PhosphorIconData(0xf069, 'duotone'),
+    PhosphorIconData(0xf069, 'Duotone'),
   );
 
   /// ![rocket-launch-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/rocket-launch-duotone.svg)
   static const rocketLaunch = PhosphorDuotoneIconData(
     0xf06c,
-    PhosphorIconData(0xf06b, 'duotone'),
+    PhosphorIconData(0xf06b, 'Duotone'),
   );
 
   /// ![rows-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/rows-duotone.svg)
   static const rows = PhosphorDuotoneIconData(
     0xf06e,
-    PhosphorIconData(0xf06d, 'duotone'),
+    PhosphorIconData(0xf06d, 'Duotone'),
   );
 
   /// ![rss-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/rss-duotone.svg)
   static const rss = PhosphorDuotoneIconData(
     0xf070,
-    PhosphorIconData(0xf06f, 'duotone'),
+    PhosphorIconData(0xf06f, 'Duotone'),
   );
 
   /// ![rss-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/rss-simple-duotone.svg)
   static const rssSimple = PhosphorDuotoneIconData(
     0xf072,
-    PhosphorIconData(0xf071, 'duotone'),
+    PhosphorIconData(0xf071, 'Duotone'),
   );
 
   /// ![rug-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/rug-duotone.svg)
   static const rug = PhosphorDuotoneIconData(
     0xf074,
-    PhosphorIconData(0xf073, 'duotone'),
+    PhosphorIconData(0xf073, 'Duotone'),
   );
 
   /// ![ruler-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/ruler-duotone.svg)
   static const ruler = PhosphorDuotoneIconData(
     0xf076,
-    PhosphorIconData(0xf075, 'duotone'),
+    PhosphorIconData(0xf075, 'Duotone'),
   );
 
   /// ![scales-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/scales-duotone.svg)
   static const scales = PhosphorDuotoneIconData(
     0xf078,
-    PhosphorIconData(0xf077, 'duotone'),
+    PhosphorIconData(0xf077, 'Duotone'),
   );
 
   /// ![scan-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/scan-duotone.svg)
   static const scan = PhosphorDuotoneIconData(
     0xf07a,
-    PhosphorIconData(0xf079, 'duotone'),
+    PhosphorIconData(0xf079, 'Duotone'),
   );
 
   /// ![scissors-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/scissors-duotone.svg)
   static const scissors = PhosphorDuotoneIconData(
     0xf07c,
-    PhosphorIconData(0xf07b, 'duotone'),
+    PhosphorIconData(0xf07b, 'Duotone'),
   );
 
   /// ![scooter-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/scooter-duotone.svg)
   static const scooter = PhosphorDuotoneIconData(
     0xf07e,
-    PhosphorIconData(0xf07d, 'duotone'),
+    PhosphorIconData(0xf07d, 'Duotone'),
   );
 
   /// ![screencast-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/screencast-duotone.svg)
   static const screencast = PhosphorDuotoneIconData(
     0xf080,
-    PhosphorIconData(0xf07f, 'duotone'),
+    PhosphorIconData(0xf07f, 'Duotone'),
   );
 
   /// ![scribble-loop-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/scribble-loop-duotone.svg)
   static const scribbleLoop = PhosphorDuotoneIconData(
     0xf082,
-    PhosphorIconData(0xf081, 'duotone'),
+    PhosphorIconData(0xf081, 'Duotone'),
   );
 
   /// ![scroll-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/scroll-duotone.svg)
   static const scroll = PhosphorDuotoneIconData(
     0xf084,
-    PhosphorIconData(0xf083, 'duotone'),
+    PhosphorIconData(0xf083, 'Duotone'),
   );
 
   /// ![seal-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/seal-duotone.svg)
   static const seal = PhosphorDuotoneIconData(
     0xf088,
-    PhosphorIconData(0xf087, 'duotone'),
+    PhosphorIconData(0xf087, 'Duotone'),
   );
 
   /// ![seal-check-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/seal-check-duotone.svg)
   static const sealCheck = PhosphorDuotoneIconData(
     0xf086,
-    PhosphorIconData(0xf085, 'duotone'),
+    PhosphorIconData(0xf085, 'Duotone'),
   );
 
   /// ![seal-question-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/seal-question-duotone.svg)
   static const sealQuestion = PhosphorDuotoneIconData(
     0xf08a,
-    PhosphorIconData(0xf089, 'duotone'),
+    PhosphorIconData(0xf089, 'Duotone'),
   );
 
   /// ![seal-warning-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/seal-warning-duotone.svg)
   static const sealWarning = PhosphorDuotoneIconData(
     0xf08c,
-    PhosphorIconData(0xf08b, 'duotone'),
+    PhosphorIconData(0xf08b, 'Duotone'),
   );
 
   /// ![selection-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/selection-duotone.svg)
   static const selection = PhosphorDuotoneIconData(
     0xf092,
-    PhosphorIconData(0xf091, 'duotone'),
+    PhosphorIconData(0xf091, 'Duotone'),
   );
 
   /// ![selection-all-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/selection-all-duotone.svg)
   static const selectionAll = PhosphorDuotoneIconData(
     0xf08e,
-    PhosphorIconData(0xf08d, 'duotone'),
+    PhosphorIconData(0xf08d, 'Duotone'),
   );
 
   /// ![selection-background-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/selection-background-duotone.svg)
   static const selectionBackground = PhosphorDuotoneIconData(
     0xf090,
-    PhosphorIconData(0xf08f, 'duotone'),
+    PhosphorIconData(0xf08f, 'Duotone'),
   );
 
   /// ![selection-foreground-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/selection-foreground-duotone.svg)
   static const selectionForeground = PhosphorDuotoneIconData(
     0xf094,
-    PhosphorIconData(0xf093, 'duotone'),
+    PhosphorIconData(0xf093, 'Duotone'),
   );
 
   /// ![selection-inverse-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/selection-inverse-duotone.svg)
   static const selectionInverse = PhosphorDuotoneIconData(
     0xf096,
-    PhosphorIconData(0xf095, 'duotone'),
+    PhosphorIconData(0xf095, 'Duotone'),
   );
 
   /// ![selection-plus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/selection-plus-duotone.svg)
   static const selectionPlus = PhosphorDuotoneIconData(
     0xf098,
-    PhosphorIconData(0xf097, 'duotone'),
+    PhosphorIconData(0xf097, 'Duotone'),
   );
 
   /// ![selection-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/selection-slash-duotone.svg)
   static const selectionSlash = PhosphorDuotoneIconData(
     0xf09a,
-    PhosphorIconData(0xf099, 'duotone'),
+    PhosphorIconData(0xf099, 'Duotone'),
   );
 
   /// ![shapes-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/shapes-duotone.svg)
   static const shapes = PhosphorDuotoneIconData(
     0xf09c,
-    PhosphorIconData(0xf09b, 'duotone'),
+    PhosphorIconData(0xf09b, 'Duotone'),
   );
 
   /// ![share-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/share-duotone.svg)
   static const share = PhosphorDuotoneIconData(
     0xf09e,
-    PhosphorIconData(0xf09d, 'duotone'),
+    PhosphorIconData(0xf09d, 'Duotone'),
   );
 
   /// ![share-fat-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/share-fat-duotone.svg)
   static const shareFat = PhosphorDuotoneIconData(
     0xf0a0,
-    PhosphorIconData(0xf09f, 'duotone'),
+    PhosphorIconData(0xf09f, 'Duotone'),
   );
 
   /// ![share-network-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/share-network-duotone.svg)
   static const shareNetwork = PhosphorDuotoneIconData(
     0xf0a2,
-    PhosphorIconData(0xf0a1, 'duotone'),
+    PhosphorIconData(0xf0a1, 'Duotone'),
   );
 
   /// ![shield-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/shield-duotone.svg)
   static const shield = PhosphorDuotoneIconData(
     0xf0aa,
-    PhosphorIconData(0xf0a9, 'duotone'),
+    PhosphorIconData(0xf0a9, 'Duotone'),
   );
 
   /// ![shield-check-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/shield-check-duotone.svg)
   static const shieldCheck = PhosphorDuotoneIconData(
     0xf0a4,
-    PhosphorIconData(0xf0a3, 'duotone'),
+    PhosphorIconData(0xf0a3, 'Duotone'),
   );
 
   /// ![shield-checkered-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/shield-checkered-duotone.svg)
   static const shieldCheckered = PhosphorDuotoneIconData(
     0xf0a6,
-    PhosphorIconData(0xf0a5, 'duotone'),
+    PhosphorIconData(0xf0a5, 'Duotone'),
   );
 
   /// ![shield-chevron-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/shield-chevron-duotone.svg)
   static const shieldChevron = PhosphorDuotoneIconData(
     0xf0a8,
-    PhosphorIconData(0xf0a7, 'duotone'),
+    PhosphorIconData(0xf0a7, 'Duotone'),
   );
 
   /// ![shield-plus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/shield-plus-duotone.svg)
   static const shieldPlus = PhosphorDuotoneIconData(
     0xf0ac,
-    PhosphorIconData(0xf0ab, 'duotone'),
+    PhosphorIconData(0xf0ab, 'Duotone'),
   );
 
   /// ![shield-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/shield-slash-duotone.svg)
   static const shieldSlash = PhosphorDuotoneIconData(
     0xf0ae,
-    PhosphorIconData(0xf0ad, 'duotone'),
+    PhosphorIconData(0xf0ad, 'Duotone'),
   );
 
   /// ![shield-star-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/shield-star-duotone.svg)
   static const shieldStar = PhosphorDuotoneIconData(
     0xf0b0,
-    PhosphorIconData(0xf0af, 'duotone'),
+    PhosphorIconData(0xf0af, 'Duotone'),
   );
 
   /// ![shield-warning-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/shield-warning-duotone.svg)
   static const shieldWarning = PhosphorDuotoneIconData(
     0xf0b2,
-    PhosphorIconData(0xf0b1, 'duotone'),
+    PhosphorIconData(0xf0b1, 'Duotone'),
   );
 
   /// ![shirt-folded-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/shirt-folded-duotone.svg)
   static const shirtFolded = PhosphorDuotoneIconData(
     0xf0b4,
-    PhosphorIconData(0xf0b3, 'duotone'),
+    PhosphorIconData(0xf0b3, 'Duotone'),
   );
 
   /// ![shooting-star-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/shooting-star-duotone.svg)
   static const shootingStar = PhosphorDuotoneIconData(
     0xf0b6,
-    PhosphorIconData(0xf0b5, 'duotone'),
+    PhosphorIconData(0xf0b5, 'Duotone'),
   );
 
   /// ![shopping-bag-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/shopping-bag-duotone.svg)
   static const shoppingBag = PhosphorDuotoneIconData(
     0xf0b8,
-    PhosphorIconData(0xf0b7, 'duotone'),
+    PhosphorIconData(0xf0b7, 'Duotone'),
   );
 
   /// ![shopping-bag-open-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/shopping-bag-open-duotone.svg)
   static const shoppingBagOpen = PhosphorDuotoneIconData(
     0xf0ba,
-    PhosphorIconData(0xf0b9, 'duotone'),
+    PhosphorIconData(0xf0b9, 'Duotone'),
   );
 
   /// ![shopping-cart-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/shopping-cart-duotone.svg)
   static const shoppingCart = PhosphorDuotoneIconData(
     0xf0bc,
-    PhosphorIconData(0xf0bb, 'duotone'),
+    PhosphorIconData(0xf0bb, 'Duotone'),
   );
 
   /// ![shopping-cart-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/shopping-cart-simple-duotone.svg)
   static const shoppingCartSimple = PhosphorDuotoneIconData(
     0xf0be,
-    PhosphorIconData(0xf0bd, 'duotone'),
+    PhosphorIconData(0xf0bd, 'Duotone'),
   );
 
   /// ![shower-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/shower-duotone.svg)
   static const shower = PhosphorDuotoneIconData(
     0xf0c0,
-    PhosphorIconData(0xf0bf, 'duotone'),
+    PhosphorIconData(0xf0bf, 'Duotone'),
   );
 
   /// ![shrimp-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/shrimp-duotone.svg)
   static const shrimp = PhosphorDuotoneIconData(
     0xf0c2,
-    PhosphorIconData(0xf0c1, 'duotone'),
+    PhosphorIconData(0xf0c1, 'Duotone'),
   );
 
   /// ![shuffle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/shuffle-duotone.svg)
   static const shuffle = PhosphorDuotoneIconData(
     0xf0c6,
-    PhosphorIconData(0xf0c5, 'duotone'),
+    PhosphorIconData(0xf0c5, 'Duotone'),
   );
 
   /// ![shuffle-angular-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/shuffle-angular-duotone.svg)
   static const shuffleAngular = PhosphorDuotoneIconData(
     0xf0c4,
-    PhosphorIconData(0xf0c3, 'duotone'),
+    PhosphorIconData(0xf0c3, 'Duotone'),
   );
 
   /// ![shuffle-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/shuffle-simple-duotone.svg)
   static const shuffleSimple = PhosphorDuotoneIconData(
     0xf0c8,
-    PhosphorIconData(0xf0c7, 'duotone'),
+    PhosphorIconData(0xf0c7, 'Duotone'),
   );
 
   /// ![sidebar-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/sidebar-duotone.svg)
   static const sidebar = PhosphorDuotoneIconData(
     0xf0ca,
-    PhosphorIconData(0xf0c9, 'duotone'),
+    PhosphorIconData(0xf0c9, 'Duotone'),
   );
 
   /// ![sidebar-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/sidebar-simple-duotone.svg)
   static const sidebarSimple = PhosphorDuotoneIconData(
     0xf0cc,
-    PhosphorIconData(0xf0cb, 'duotone'),
+    PhosphorIconData(0xf0cb, 'Duotone'),
   );
 
   /// ![sigma-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/sigma-duotone.svg)
   static const sigma = PhosphorDuotoneIconData(
     0xf0ce,
-    PhosphorIconData(0xf0cd, 'duotone'),
+    PhosphorIconData(0xf0cd, 'Duotone'),
   );
 
   /// ![sign-in-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/sign-in-duotone.svg)
   static const signIn = PhosphorDuotoneIconData(
     0xf0d2,
-    PhosphorIconData(0xf0d1, 'duotone'),
+    PhosphorIconData(0xf0d1, 'Duotone'),
   );
 
   /// ![sign-out-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/sign-out-duotone.svg)
   static const signOut = PhosphorDuotoneIconData(
     0xf0d4,
-    PhosphorIconData(0xf0d3, 'duotone'),
+    PhosphorIconData(0xf0d3, 'Duotone'),
   );
 
   /// ![signature-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/signature-duotone.svg)
   static const signature = PhosphorDuotoneIconData(
     0xf0d0,
-    PhosphorIconData(0xf0cf, 'duotone'),
+    PhosphorIconData(0xf0cf, 'Duotone'),
   );
 
   /// ![signpost-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/signpost-duotone.svg)
   static const signpost = PhosphorDuotoneIconData(
     0xf0d6,
-    PhosphorIconData(0xf0d5, 'duotone'),
+    PhosphorIconData(0xf0d5, 'Duotone'),
   );
 
   /// ![sim-card-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/sim-card-duotone.svg)
   static const simCard = PhosphorDuotoneIconData(
     0xf0d8,
-    PhosphorIconData(0xf0d7, 'duotone'),
+    PhosphorIconData(0xf0d7, 'Duotone'),
   );
 
   /// ![siren-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/siren-duotone.svg)
   static const siren = PhosphorDuotoneIconData(
     0xf0da,
-    PhosphorIconData(0xf0d9, 'duotone'),
+    PhosphorIconData(0xf0d9, 'Duotone'),
   );
 
   /// ![sketch-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/sketch-logo-duotone.svg)
   static const sketchLogo = PhosphorDuotoneIconData(
     0xf0dc,
-    PhosphorIconData(0xf0db, 'duotone'),
+    PhosphorIconData(0xf0db, 'Duotone'),
   );
 
   /// ![skip-back-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/skip-back-duotone.svg)
   static const skipBack = PhosphorDuotoneIconData(
     0xf0e0,
-    PhosphorIconData(0xf0df, 'duotone'),
+    PhosphorIconData(0xf0df, 'Duotone'),
   );
 
   /// ![skip-back-circle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/skip-back-circle-duotone.svg)
   static const skipBackCircle = PhosphorDuotoneIconData(
     0xf0de,
-    PhosphorIconData(0xf0dd, 'duotone'),
+    PhosphorIconData(0xf0dd, 'Duotone'),
   );
 
   /// ![skip-forward-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/skip-forward-duotone.svg)
   static const skipForward = PhosphorDuotoneIconData(
     0xf0e4,
-    PhosphorIconData(0xf0e3, 'duotone'),
+    PhosphorIconData(0xf0e3, 'Duotone'),
   );
 
   /// ![skip-forward-circle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/skip-forward-circle-duotone.svg)
   static const skipForwardCircle = PhosphorDuotoneIconData(
     0xf0e2,
-    PhosphorIconData(0xf0e1, 'duotone'),
+    PhosphorIconData(0xf0e1, 'Duotone'),
   );
 
   /// ![skull-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/skull-duotone.svg)
   static const skull = PhosphorDuotoneIconData(
     0xf0e6,
-    PhosphorIconData(0xf0e5, 'duotone'),
+    PhosphorIconData(0xf0e5, 'Duotone'),
   );
 
   /// ![slack-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/slack-logo-duotone.svg)
   static const slackLogo = PhosphorDuotoneIconData(
     0xf0e8,
-    PhosphorIconData(0xf0e7, 'duotone'),
+    PhosphorIconData(0xf0e7, 'Duotone'),
   );
 
   /// ![sliders-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/sliders-duotone.svg)
   static const sliders = PhosphorDuotoneIconData(
     0xf0ea,
-    PhosphorIconData(0xf0e9, 'duotone'),
+    PhosphorIconData(0xf0e9, 'Duotone'),
   );
 
   /// ![sliders-horizontal-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/sliders-horizontal-duotone.svg)
   static const slidersHorizontal = PhosphorDuotoneIconData(
     0xf0ec,
-    PhosphorIconData(0xf0eb, 'duotone'),
+    PhosphorIconData(0xf0eb, 'Duotone'),
   );
 
   /// ![slideshow-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/slideshow-duotone.svg)
   static const slideshow = PhosphorDuotoneIconData(
     0xf0ee,
-    PhosphorIconData(0xf0ed, 'duotone'),
+    PhosphorIconData(0xf0ed, 'Duotone'),
   );
 
   /// ![smiley-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/smiley-duotone.svg)
   static const smiley = PhosphorDuotoneIconData(
     0xf0f4,
-    PhosphorIconData(0xf0f3, 'duotone'),
+    PhosphorIconData(0xf0f3, 'Duotone'),
   );
 
   /// ![smiley-angry-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/smiley-angry-duotone.svg)
   static const smileyAngry = PhosphorDuotoneIconData(
     0xf0f0,
-    PhosphorIconData(0xf0ef, 'duotone'),
+    PhosphorIconData(0xf0ef, 'Duotone'),
   );
 
   /// ![smiley-blank-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/smiley-blank-duotone.svg)
   static const smileyBlank = PhosphorDuotoneIconData(
     0xf0f2,
-    PhosphorIconData(0xf0f1, 'duotone'),
+    PhosphorIconData(0xf0f1, 'Duotone'),
   );
 
   /// ![smiley-meh-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/smiley-meh-duotone.svg)
   static const smileyMeh = PhosphorDuotoneIconData(
     0xf0f6,
-    PhosphorIconData(0xf0f5, 'duotone'),
+    PhosphorIconData(0xf0f5, 'Duotone'),
   );
 
   /// ![smiley-nervous-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/smiley-nervous-duotone.svg)
   static const smileyNervous = PhosphorDuotoneIconData(
     0xf0f8,
-    PhosphorIconData(0xf0f7, 'duotone'),
+    PhosphorIconData(0xf0f7, 'Duotone'),
   );
 
   /// ![smiley-sad-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/smiley-sad-duotone.svg)
   static const smileySad = PhosphorDuotoneIconData(
     0xf0fa,
-    PhosphorIconData(0xf0f9, 'duotone'),
+    PhosphorIconData(0xf0f9, 'Duotone'),
   );
 
   /// ![smiley-sticker-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/smiley-sticker-duotone.svg)
   static const smileySticker = PhosphorDuotoneIconData(
     0xf0fc,
-    PhosphorIconData(0xf0fb, 'duotone'),
+    PhosphorIconData(0xf0fb, 'Duotone'),
   );
 
   /// ![smiley-wink-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/smiley-wink-duotone.svg)
   static const smileyWink = PhosphorDuotoneIconData(
     0xf0fe,
-    PhosphorIconData(0xf0fd, 'duotone'),
+    PhosphorIconData(0xf0fd, 'Duotone'),
   );
 
   /// ![smiley-x-eyes-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/smiley-x-eyes-duotone.svg)
   static const smileyXEyes = PhosphorDuotoneIconData(
     0xf100,
-    PhosphorIconData(0xf0ff, 'duotone'),
+    PhosphorIconData(0xf0ff, 'Duotone'),
   );
 
   /// ![snapchat-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/snapchat-logo-duotone.svg)
   static const snapchatLogo = PhosphorDuotoneIconData(
     0xf102,
-    PhosphorIconData(0xf101, 'duotone'),
+    PhosphorIconData(0xf101, 'Duotone'),
   );
 
   /// ![sneaker-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/sneaker-duotone.svg)
   static const sneaker = PhosphorDuotoneIconData(
     0xf104,
-    PhosphorIconData(0xf103, 'duotone'),
+    PhosphorIconData(0xf103, 'Duotone'),
   );
 
   /// ![sneaker-move-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/sneaker-move-duotone.svg)
   static const sneakerMove = PhosphorDuotoneIconData(
     0xf106,
-    PhosphorIconData(0xf105, 'duotone'),
+    PhosphorIconData(0xf105, 'Duotone'),
   );
 
   /// ![snowflake-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/snowflake-duotone.svg)
   static const snowflake = PhosphorDuotoneIconData(
     0xf108,
-    PhosphorIconData(0xf107, 'duotone'),
+    PhosphorIconData(0xf107, 'Duotone'),
   );
 
   /// ![soccer-ball-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/soccer-ball-duotone.svg)
   static const soccerBall = PhosphorDuotoneIconData(
     0xf10a,
-    PhosphorIconData(0xf109, 'duotone'),
+    PhosphorIconData(0xf109, 'Duotone'),
   );
 
   /// ![sort-ascending-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/sort-ascending-duotone.svg)
   static const sortAscending = PhosphorDuotoneIconData(
     0xf10c,
-    PhosphorIconData(0xf10b, 'duotone'),
+    PhosphorIconData(0xf10b, 'Duotone'),
   );
 
   /// ![sort-descending-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/sort-descending-duotone.svg)
   static const sortDescending = PhosphorDuotoneIconData(
     0xf10e,
-    PhosphorIconData(0xf10d, 'duotone'),
+    PhosphorIconData(0xf10d, 'Duotone'),
   );
 
   /// ![soundcloud-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/soundcloud-logo-duotone.svg)
   static const soundcloudLogo = PhosphorDuotoneIconData(
     0xf110,
-    PhosphorIconData(0xf10f, 'duotone'),
+    PhosphorIconData(0xf10f, 'Duotone'),
   );
 
   /// ![spade-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/spade-duotone.svg)
   static const spade = PhosphorDuotoneIconData(
     0xf112,
-    PhosphorIconData(0xf111, 'duotone'),
+    PhosphorIconData(0xf111, 'Duotone'),
   );
 
   /// ![sparkle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/sparkle-duotone.svg)
   static const sparkle = PhosphorDuotoneIconData(
     0xf114,
-    PhosphorIconData(0xf113, 'duotone'),
+    PhosphorIconData(0xf113, 'Duotone'),
   );
 
   /// ![speaker-hifi-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/speaker-hifi-duotone.svg)
   static const speakerHifi = PhosphorDuotoneIconData(
     0xf116,
-    PhosphorIconData(0xf115, 'duotone'),
+    PhosphorIconData(0xf115, 'Duotone'),
   );
 
   /// ![speaker-high-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/speaker-high-duotone.svg)
   static const speakerHigh = PhosphorDuotoneIconData(
     0xf118,
-    PhosphorIconData(0xf117, 'duotone'),
+    PhosphorIconData(0xf117, 'Duotone'),
   );
 
   /// ![speaker-low-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/speaker-low-duotone.svg)
   static const speakerLow = PhosphorDuotoneIconData(
     0xf11a,
-    PhosphorIconData(0xf119, 'duotone'),
+    PhosphorIconData(0xf119, 'Duotone'),
   );
 
   /// ![speaker-none-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/speaker-none-duotone.svg)
   static const speakerNone = PhosphorDuotoneIconData(
     0xf11c,
-    PhosphorIconData(0xf11b, 'duotone'),
+    PhosphorIconData(0xf11b, 'Duotone'),
   );
 
   /// ![speaker-simple-high-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/speaker-simple-high-duotone.svg)
   static const speakerSimpleHigh = PhosphorDuotoneIconData(
     0xf11e,
-    PhosphorIconData(0xf11d, 'duotone'),
+    PhosphorIconData(0xf11d, 'Duotone'),
   );
 
   /// ![speaker-simple-low-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/speaker-simple-low-duotone.svg)
   static const speakerSimpleLow = PhosphorDuotoneIconData(
     0xf120,
-    PhosphorIconData(0xf11f, 'duotone'),
+    PhosphorIconData(0xf11f, 'Duotone'),
   );
 
   /// ![speaker-simple-none-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/speaker-simple-none-duotone.svg)
   static const speakerSimpleNone = PhosphorDuotoneIconData(
     0xf122,
-    PhosphorIconData(0xf121, 'duotone'),
+    PhosphorIconData(0xf121, 'Duotone'),
   );
 
   /// ![speaker-simple-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/speaker-simple-slash-duotone.svg)
   static const speakerSimpleSlash = PhosphorDuotoneIconData(
     0xf124,
-    PhosphorIconData(0xf123, 'duotone'),
+    PhosphorIconData(0xf123, 'Duotone'),
   );
 
   /// ![speaker-simple-x-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/speaker-simple-x-duotone.svg)
   static const speakerSimpleX = PhosphorDuotoneIconData(
     0xf126,
-    PhosphorIconData(0xf125, 'duotone'),
+    PhosphorIconData(0xf125, 'Duotone'),
   );
 
   /// ![speaker-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/speaker-slash-duotone.svg)
   static const speakerSlash = PhosphorDuotoneIconData(
     0xf128,
-    PhosphorIconData(0xf127, 'duotone'),
+    PhosphorIconData(0xf127, 'Duotone'),
   );
 
   /// ![speaker-x-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/speaker-x-duotone.svg)
   static const speakerX = PhosphorDuotoneIconData(
     0xf12a,
-    PhosphorIconData(0xf129, 'duotone'),
+    PhosphorIconData(0xf129, 'Duotone'),
   );
 
   /// ![spinner-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/spinner-duotone.svg)
   static const spinner = PhosphorDuotoneIconData(
     0xf12c,
-    PhosphorIconData(0xf12b, 'duotone'),
+    PhosphorIconData(0xf12b, 'Duotone'),
   );
 
   /// ![spinner-gap-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/spinner-gap-duotone.svg)
   static const spinnerGap = PhosphorDuotoneIconData(
     0xf12e,
-    PhosphorIconData(0xf12d, 'duotone'),
+    PhosphorIconData(0xf12d, 'Duotone'),
   );
 
   /// ![spiral-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/spiral-duotone.svg)
   static const spiral = PhosphorDuotoneIconData(
     0xf130,
-    PhosphorIconData(0xf12f, 'duotone'),
+    PhosphorIconData(0xf12f, 'Duotone'),
   );
 
   /// ![split-horizontal-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/split-horizontal-duotone.svg)
   static const splitHorizontal = PhosphorDuotoneIconData(
     0xf132,
-    PhosphorIconData(0xf131, 'duotone'),
+    PhosphorIconData(0xf131, 'Duotone'),
   );
 
   /// ![split-vertical-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/split-vertical-duotone.svg)
   static const splitVertical = PhosphorDuotoneIconData(
     0xf134,
-    PhosphorIconData(0xf133, 'duotone'),
+    PhosphorIconData(0xf133, 'Duotone'),
   );
 
   /// ![spotify-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/spotify-logo-duotone.svg)
   static const spotifyLogo = PhosphorDuotoneIconData(
     0xf136,
-    PhosphorIconData(0xf135, 'duotone'),
+    PhosphorIconData(0xf135, 'Duotone'),
   );
 
   /// ![square-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/square-duotone.svg)
   static const square = PhosphorDuotoneIconData(
     0xf138,
-    PhosphorIconData(0xf137, 'duotone'),
+    PhosphorIconData(0xf137, 'Duotone'),
   );
 
   /// ![square-half-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/square-half-duotone.svg)
   static const squareHalf = PhosphorDuotoneIconData(
     0xf13c,
-    PhosphorIconData(0xf13b, 'duotone'),
+    PhosphorIconData(0xf13b, 'Duotone'),
   );
 
   /// ![square-half-bottom-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/square-half-bottom-duotone.svg)
   static const squareHalfBottom = PhosphorDuotoneIconData(
     0xf13a,
-    PhosphorIconData(0xf139, 'duotone'),
+    PhosphorIconData(0xf139, 'Duotone'),
   );
 
   /// ![square-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/square-logo-duotone.svg)
   static const squareLogo = PhosphorDuotoneIconData(
     0xf13e,
-    PhosphorIconData(0xf13d, 'duotone'),
+    PhosphorIconData(0xf13d, 'Duotone'),
   );
 
   /// ![square-split-horizontal-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/square-split-horizontal-duotone.svg)
   static const squareSplitHorizontal = PhosphorDuotoneIconData(
     0xf142,
-    PhosphorIconData(0xf141, 'duotone'),
+    PhosphorIconData(0xf141, 'Duotone'),
   );
 
   /// ![square-split-vertical-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/square-split-vertical-duotone.svg)
   static const squareSplitVertical = PhosphorDuotoneIconData(
     0xf144,
-    PhosphorIconData(0xf143, 'duotone'),
+    PhosphorIconData(0xf143, 'Duotone'),
   );
 
   /// ![squares-four-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/squares-four-duotone.svg)
   static const squaresFour = PhosphorDuotoneIconData(
     0xf140,
-    PhosphorIconData(0xf13f, 'duotone'),
+    PhosphorIconData(0xf13f, 'Duotone'),
   );
 
   /// ![stack-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/stack-duotone.svg)
   static const stack = PhosphorDuotoneIconData(
     0xf146,
-    PhosphorIconData(0xf145, 'duotone'),
+    PhosphorIconData(0xf145, 'Duotone'),
   );
 
   /// ![stack-overflow-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/stack-overflow-logo-duotone.svg)
   static const stackOverflowLogo = PhosphorDuotoneIconData(
     0xf148,
-    PhosphorIconData(0xf147, 'duotone'),
+    PhosphorIconData(0xf147, 'Duotone'),
   );
 
   /// ![stack-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/stack-simple-duotone.svg)
   static const stackSimple = PhosphorDuotoneIconData(
     0xf14a,
-    PhosphorIconData(0xf149, 'duotone'),
+    PhosphorIconData(0xf149, 'Duotone'),
   );
 
   /// ![stairs-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/stairs-duotone.svg)
   static const stairs = PhosphorDuotoneIconData(
     0xf14c,
-    PhosphorIconData(0xf14b, 'duotone'),
+    PhosphorIconData(0xf14b, 'Duotone'),
   );
 
   /// ![stamp-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/stamp-duotone.svg)
   static const stamp = PhosphorDuotoneIconData(
     0xf14e,
-    PhosphorIconData(0xf14d, 'duotone'),
+    PhosphorIconData(0xf14d, 'Duotone'),
   );
 
   /// ![star-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/star-duotone.svg)
   static const star = PhosphorDuotoneIconData(
     0xf152,
-    PhosphorIconData(0xf151, 'duotone'),
+    PhosphorIconData(0xf151, 'Duotone'),
   );
 
   /// ![star-and-crescent-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/star-and-crescent-duotone.svg)
   static const starAndCrescent = PhosphorDuotoneIconData(
     0xf150,
-    PhosphorIconData(0xf14f, 'duotone'),
+    PhosphorIconData(0xf14f, 'Duotone'),
   );
 
   /// ![star-four-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/star-four-duotone.svg)
   static const starFour = PhosphorDuotoneIconData(
     0xf154,
-    PhosphorIconData(0xf153, 'duotone'),
+    PhosphorIconData(0xf153, 'Duotone'),
   );
 
   /// ![star-half-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/star-half-duotone.svg)
   static const starHalf = PhosphorDuotoneIconData(
     0xf156,
-    PhosphorIconData(0xf155, 'duotone'),
+    PhosphorIconData(0xf155, 'Duotone'),
   );
 
   /// ![star-of-david-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/star-of-david-duotone.svg)
   static const starOfDavid = PhosphorDuotoneIconData(
     0xf158,
-    PhosphorIconData(0xf157, 'duotone'),
+    PhosphorIconData(0xf157, 'Duotone'),
   );
 
   /// ![steering-wheel-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/steering-wheel-duotone.svg)
   static const steeringWheel = PhosphorDuotoneIconData(
     0xf15a,
-    PhosphorIconData(0xf159, 'duotone'),
+    PhosphorIconData(0xf159, 'Duotone'),
   );
 
   /// ![steps-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/steps-duotone.svg)
   static const steps = PhosphorDuotoneIconData(
     0xf15c,
-    PhosphorIconData(0xf15b, 'duotone'),
+    PhosphorIconData(0xf15b, 'Duotone'),
   );
 
   /// ![stethoscope-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/stethoscope-duotone.svg)
   static const stethoscope = PhosphorDuotoneIconData(
     0xf15e,
-    PhosphorIconData(0xf15d, 'duotone'),
+    PhosphorIconData(0xf15d, 'Duotone'),
   );
 
   /// ![sticker-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/sticker-duotone.svg)
   static const sticker = PhosphorDuotoneIconData(
     0xf160,
-    PhosphorIconData(0xf15f, 'duotone'),
+    PhosphorIconData(0xf15f, 'Duotone'),
   );
 
   /// ![stool-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/stool-duotone.svg)
   static const stool = PhosphorDuotoneIconData(
     0xf162,
-    PhosphorIconData(0xf161, 'duotone'),
+    PhosphorIconData(0xf161, 'Duotone'),
   );
 
   /// ![stop-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/stop-duotone.svg)
   static const stop = PhosphorDuotoneIconData(
     0xf166,
-    PhosphorIconData(0xf165, 'duotone'),
+    PhosphorIconData(0xf165, 'Duotone'),
   );
 
   /// ![stop-circle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/stop-circle-duotone.svg)
   static const stopCircle = PhosphorDuotoneIconData(
     0xf164,
-    PhosphorIconData(0xf163, 'duotone'),
+    PhosphorIconData(0xf163, 'Duotone'),
   );
 
   /// ![storefront-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/storefront-duotone.svg)
   static const storefront = PhosphorDuotoneIconData(
     0xf168,
-    PhosphorIconData(0xf167, 'duotone'),
+    PhosphorIconData(0xf167, 'Duotone'),
   );
 
   /// ![strategy-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/strategy-duotone.svg)
   static const strategy = PhosphorDuotoneIconData(
     0xf16a,
-    PhosphorIconData(0xf169, 'duotone'),
+    PhosphorIconData(0xf169, 'Duotone'),
   );
 
   /// ![stripe-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/stripe-logo-duotone.svg)
   static const stripeLogo = PhosphorDuotoneIconData(
     0xf16c,
-    PhosphorIconData(0xf16b, 'duotone'),
+    PhosphorIconData(0xf16b, 'Duotone'),
   );
 
   /// ![student-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/student-duotone.svg)
   static const student = PhosphorDuotoneIconData(
     0xf16e,
-    PhosphorIconData(0xf16d, 'duotone'),
+    PhosphorIconData(0xf16d, 'Duotone'),
   );
 
   /// ![subtitles-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/subtitles-duotone.svg)
   static const subtitles = PhosphorDuotoneIconData(
     0xf170,
-    PhosphorIconData(0xf16f, 'duotone'),
+    PhosphorIconData(0xf16f, 'Duotone'),
   );
 
   /// ![subtract-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/subtract-duotone.svg)
   static const subtract = PhosphorDuotoneIconData(
     0xf172,
-    PhosphorIconData(0xf171, 'duotone'),
+    PhosphorIconData(0xf171, 'Duotone'),
   );
 
   /// ![subtract-square-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/subtract-square-duotone.svg)
   static const subtractSquare = PhosphorDuotoneIconData(
     0xf174,
-    PhosphorIconData(0xf173, 'duotone'),
+    PhosphorIconData(0xf173, 'Duotone'),
   );
 
   /// ![suitcase-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/suitcase-duotone.svg)
   static const suitcase = PhosphorDuotoneIconData(
     0xf176,
-    PhosphorIconData(0xf175, 'duotone'),
+    PhosphorIconData(0xf175, 'Duotone'),
   );
 
   /// ![suitcase-rolling-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/suitcase-rolling-duotone.svg)
   static const suitcaseRolling = PhosphorDuotoneIconData(
     0xf178,
-    PhosphorIconData(0xf177, 'duotone'),
+    PhosphorIconData(0xf177, 'Duotone'),
   );
 
   /// ![suitcase-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/suitcase-simple-duotone.svg)
   static const suitcaseSimple = PhosphorDuotoneIconData(
     0xf17a,
-    PhosphorIconData(0xf179, 'duotone'),
+    PhosphorIconData(0xf179, 'Duotone'),
   );
 
   /// ![sun-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/sun-duotone.svg)
   static const sun = PhosphorDuotoneIconData(
     0xf17e,
-    PhosphorIconData(0xf17d, 'duotone'),
+    PhosphorIconData(0xf17d, 'Duotone'),
   );
 
   /// ![sun-dim-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/sun-dim-duotone.svg)
   static const sunDim = PhosphorDuotoneIconData(
     0xf17c,
-    PhosphorIconData(0xf17b, 'duotone'),
+    PhosphorIconData(0xf17b, 'Duotone'),
   );
 
   /// ![sun-horizon-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/sun-horizon-duotone.svg)
   static const sunHorizon = PhosphorDuotoneIconData(
     0xf182,
-    PhosphorIconData(0xf181, 'duotone'),
+    PhosphorIconData(0xf181, 'Duotone'),
   );
 
   /// ![sunglasses-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/sunglasses-duotone.svg)
   static const sunglasses = PhosphorDuotoneIconData(
     0xf180,
-    PhosphorIconData(0xf17f, 'duotone'),
+    PhosphorIconData(0xf17f, 'Duotone'),
   );
 
   /// ![swap-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/swap-duotone.svg)
   static const swap = PhosphorDuotoneIconData(
     0xf184,
-    PhosphorIconData(0xf183, 'duotone'),
+    PhosphorIconData(0xf183, 'Duotone'),
   );
 
   /// ![swatches-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/swatches-duotone.svg)
   static const swatches = PhosphorDuotoneIconData(
     0xf186,
-    PhosphorIconData(0xf185, 'duotone'),
+    PhosphorIconData(0xf185, 'Duotone'),
   );
 
   /// ![swimming-pool-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/swimming-pool-duotone.svg)
   static const swimmingPool = PhosphorDuotoneIconData(
     0xf188,
-    PhosphorIconData(0xf187, 'duotone'),
+    PhosphorIconData(0xf187, 'Duotone'),
   );
 
   /// ![sword-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/sword-duotone.svg)
   static const sword = PhosphorDuotoneIconData(
     0xf18a,
-    PhosphorIconData(0xf189, 'duotone'),
+    PhosphorIconData(0xf189, 'Duotone'),
   );
 
   /// ![synagogue-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/synagogue-duotone.svg)
   static const synagogue = PhosphorDuotoneIconData(
     0xf18c,
-    PhosphorIconData(0xf18b, 'duotone'),
+    PhosphorIconData(0xf18b, 'Duotone'),
   );
 
   /// ![syringe-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/syringe-duotone.svg)
   static const syringe = PhosphorDuotoneIconData(
     0xf18e,
-    PhosphorIconData(0xf18d, 'duotone'),
+    PhosphorIconData(0xf18d, 'Duotone'),
   );
 
   /// ![t-shirt-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/t-shirt-duotone.svg)
   static const tShirt = PhosphorDuotoneIconData(
     0xf22c,
-    PhosphorIconData(0xf22b, 'duotone'),
+    PhosphorIconData(0xf22b, 'Duotone'),
   );
 
   /// ![table-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/table-duotone.svg)
   static const table = PhosphorDuotoneIconData(
     0xf190,
-    PhosphorIconData(0xf18f, 'duotone'),
+    PhosphorIconData(0xf18f, 'Duotone'),
   );
 
   /// ![tabs-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/tabs-duotone.svg)
   static const tabs = PhosphorDuotoneIconData(
     0xf192,
-    PhosphorIconData(0xf191, 'duotone'),
+    PhosphorIconData(0xf191, 'Duotone'),
   );
 
   /// ![tag-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/tag-duotone.svg)
   static const tag = PhosphorDuotoneIconData(
     0xf196,
-    PhosphorIconData(0xf195, 'duotone'),
+    PhosphorIconData(0xf195, 'Duotone'),
   );
 
   /// ![tag-chevron-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/tag-chevron-duotone.svg)
   static const tagChevron = PhosphorDuotoneIconData(
     0xf194,
-    PhosphorIconData(0xf193, 'duotone'),
+    PhosphorIconData(0xf193, 'Duotone'),
   );
 
   /// ![tag-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/tag-simple-duotone.svg)
   static const tagSimple = PhosphorDuotoneIconData(
     0xf198,
-    PhosphorIconData(0xf197, 'duotone'),
+    PhosphorIconData(0xf197, 'Duotone'),
   );
 
   /// ![target-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/target-duotone.svg)
   static const target = PhosphorDuotoneIconData(
     0xf19a,
-    PhosphorIconData(0xf199, 'duotone'),
+    PhosphorIconData(0xf199, 'Duotone'),
   );
 
   /// ![taxi-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/taxi-duotone.svg)
   static const taxi = PhosphorDuotoneIconData(
     0xf19c,
-    PhosphorIconData(0xf19b, 'duotone'),
+    PhosphorIconData(0xf19b, 'Duotone'),
   );
 
   /// ![telegram-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/telegram-logo-duotone.svg)
   static const telegramLogo = PhosphorDuotoneIconData(
     0xf19e,
-    PhosphorIconData(0xf19d, 'duotone'),
+    PhosphorIconData(0xf19d, 'Duotone'),
   );
 
   /// ![television-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/television-duotone.svg)
   static const television = PhosphorDuotoneIconData(
     0xf1a0,
-    PhosphorIconData(0xf19f, 'duotone'),
+    PhosphorIconData(0xf19f, 'Duotone'),
   );
 
   /// ![television-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/television-simple-duotone.svg)
   static const televisionSimple = PhosphorDuotoneIconData(
     0xf1a2,
-    PhosphorIconData(0xf1a1, 'duotone'),
+    PhosphorIconData(0xf1a1, 'Duotone'),
   );
 
   /// ![tennis-ball-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/tennis-ball-duotone.svg)
   static const tennisBall = PhosphorDuotoneIconData(
     0xf1a4,
-    PhosphorIconData(0xf1a3, 'duotone'),
+    PhosphorIconData(0xf1a3, 'Duotone'),
   );
 
   /// ![tent-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/tent-duotone.svg)
   static const tent = PhosphorDuotoneIconData(
     0xf1a6,
-    PhosphorIconData(0xf1a5, 'duotone'),
+    PhosphorIconData(0xf1a5, 'Duotone'),
   );
 
   /// ![terminal-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/terminal-duotone.svg)
   static const terminal = PhosphorDuotoneIconData(
     0xf1a8,
-    PhosphorIconData(0xf1a7, 'duotone'),
+    PhosphorIconData(0xf1a7, 'Duotone'),
   );
 
   /// ![terminal-window-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/terminal-window-duotone.svg)
   static const terminalWindow = PhosphorDuotoneIconData(
     0xf1aa,
-    PhosphorIconData(0xf1a9, 'duotone'),
+    PhosphorIconData(0xf1a9, 'Duotone'),
   );
 
   /// ![test-tube-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/test-tube-duotone.svg)
   static const testTube = PhosphorDuotoneIconData(
     0xf1ac,
-    PhosphorIconData(0xf1ab, 'duotone'),
+    PhosphorIconData(0xf1ab, 'Duotone'),
   );
 
   /// ![text-a-underline-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/text-a-underline-duotone.svg)
   static const textAUnderline = PhosphorDuotoneIconData(
     0xf1b8,
-    PhosphorIconData(0xf1b7, 'duotone'),
+    PhosphorIconData(0xf1b7, 'Duotone'),
   );
 
   /// ![text-aa-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/text-aa-duotone.svg)
   static const textAa = PhosphorDuotoneIconData(
     0xf1ae,
-    PhosphorIconData(0xf1ad, 'duotone'),
+    PhosphorIconData(0xf1ad, 'Duotone'),
   );
 
   /// ![text-align-center-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/text-align-center-duotone.svg)
   static const textAlignCenter = PhosphorDuotoneIconData(
     0xf1b0,
-    PhosphorIconData(0xf1af, 'duotone'),
+    PhosphorIconData(0xf1af, 'Duotone'),
   );
 
   /// ![text-align-justify-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/text-align-justify-duotone.svg)
   static const textAlignJustify = PhosphorDuotoneIconData(
     0xf1b2,
-    PhosphorIconData(0xf1b1, 'duotone'),
+    PhosphorIconData(0xf1b1, 'Duotone'),
   );
 
   /// ![text-align-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/text-align-left-duotone.svg)
   static const textAlignLeft = PhosphorDuotoneIconData(
     0xf1b4,
-    PhosphorIconData(0xf1b3, 'duotone'),
+    PhosphorIconData(0xf1b3, 'Duotone'),
   );
 
   /// ![text-align-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/text-align-right-duotone.svg)
   static const textAlignRight = PhosphorDuotoneIconData(
     0xf1b6,
-    PhosphorIconData(0xf1b5, 'duotone'),
+    PhosphorIconData(0xf1b5, 'Duotone'),
   );
 
   /// ![text-b-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/text-b-duotone.svg)
   static const textB = PhosphorDuotoneIconData(
     0xf1ba,
-    PhosphorIconData(0xf1b9, 'duotone'),
+    PhosphorIconData(0xf1b9, 'Duotone'),
   );
 
   /// ![text-columns-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/text-columns-duotone.svg)
   static const textColumns = PhosphorDuotoneIconData(
     0xf1be,
-    PhosphorIconData(0xf1bd, 'duotone'),
+    PhosphorIconData(0xf1bd, 'Duotone'),
   );
 
   /// ![text-h-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/text-h-duotone.svg)
   static const textH = PhosphorDuotoneIconData(
     0xf1c0,
-    PhosphorIconData(0xf1bf, 'duotone'),
+    PhosphorIconData(0xf1bf, 'Duotone'),
   );
 
   /// ![text-h-five-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/text-h-five-duotone.svg)
   static const textHFive = PhosphorDuotoneIconData(
     0xf1c2,
-    PhosphorIconData(0xf1c1, 'duotone'),
+    PhosphorIconData(0xf1c1, 'Duotone'),
   );
 
   /// ![text-h-four-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/text-h-four-duotone.svg)
   static const textHFour = PhosphorDuotoneIconData(
     0xf1c4,
-    PhosphorIconData(0xf1c3, 'duotone'),
+    PhosphorIconData(0xf1c3, 'Duotone'),
   );
 
   /// ![text-h-one-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/text-h-one-duotone.svg)
   static const textHOne = PhosphorDuotoneIconData(
     0xf1c6,
-    PhosphorIconData(0xf1c5, 'duotone'),
+    PhosphorIconData(0xf1c5, 'Duotone'),
   );
 
   /// ![text-h-six-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/text-h-six-duotone.svg)
   static const textHSix = PhosphorDuotoneIconData(
     0xf1c8,
-    PhosphorIconData(0xf1c7, 'duotone'),
+    PhosphorIconData(0xf1c7, 'Duotone'),
   );
 
   /// ![text-h-three-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/text-h-three-duotone.svg)
   static const textHThree = PhosphorDuotoneIconData(
     0xf1ca,
-    PhosphorIconData(0xf1c9, 'duotone'),
+    PhosphorIconData(0xf1c9, 'Duotone'),
   );
 
   /// ![text-h-two-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/text-h-two-duotone.svg)
   static const textHTwo = PhosphorDuotoneIconData(
     0xf1cc,
-    PhosphorIconData(0xf1cb, 'duotone'),
+    PhosphorIconData(0xf1cb, 'Duotone'),
   );
 
   /// ![text-indent-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/text-indent-duotone.svg)
   static const textIndent = PhosphorDuotoneIconData(
     0xf1ce,
-    PhosphorIconData(0xf1cd, 'duotone'),
+    PhosphorIconData(0xf1cd, 'Duotone'),
   );
 
   /// ![text-italic-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/text-italic-duotone.svg)
   static const textItalic = PhosphorDuotoneIconData(
     0xf1d0,
-    PhosphorIconData(0xf1cf, 'duotone'),
+    PhosphorIconData(0xf1cf, 'Duotone'),
   );
 
   /// ![text-outdent-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/text-outdent-duotone.svg)
   static const textOutdent = PhosphorDuotoneIconData(
     0xf1d2,
-    PhosphorIconData(0xf1d1, 'duotone'),
+    PhosphorIconData(0xf1d1, 'Duotone'),
   );
 
   /// ![text-strikethrough-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/text-strikethrough-duotone.svg)
   static const textStrikethrough = PhosphorDuotoneIconData(
     0xf1d4,
-    PhosphorIconData(0xf1d3, 'duotone'),
+    PhosphorIconData(0xf1d3, 'Duotone'),
   );
 
   /// ![text-t-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/text-t-duotone.svg)
   static const textT = PhosphorDuotoneIconData(
     0xf1d6,
-    PhosphorIconData(0xf1d5, 'duotone'),
+    PhosphorIconData(0xf1d5, 'Duotone'),
   );
 
   /// ![text-underline-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/text-underline-duotone.svg)
   static const textUnderline = PhosphorDuotoneIconData(
     0xf1d8,
-    PhosphorIconData(0xf1d7, 'duotone'),
+    PhosphorIconData(0xf1d7, 'Duotone'),
   );
 
   /// ![textbox-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/textbox-duotone.svg)
   static const textbox = PhosphorDuotoneIconData(
     0xf1bc,
-    PhosphorIconData(0xf1bb, 'duotone'),
+    PhosphorIconData(0xf1bb, 'Duotone'),
   );
 
   /// ![thermometer-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/thermometer-duotone.svg)
   static const thermometer = PhosphorDuotoneIconData(
     0xf1dc,
-    PhosphorIconData(0xf1db, 'duotone'),
+    PhosphorIconData(0xf1db, 'Duotone'),
   );
 
   /// ![thermometer-cold-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/thermometer-cold-duotone.svg)
   static const thermometerCold = PhosphorDuotoneIconData(
     0xf1da,
-    PhosphorIconData(0xf1d9, 'duotone'),
+    PhosphorIconData(0xf1d9, 'Duotone'),
   );
 
   /// ![thermometer-hot-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/thermometer-hot-duotone.svg)
   static const thermometerHot = PhosphorDuotoneIconData(
     0xf1de,
-    PhosphorIconData(0xf1dd, 'duotone'),
+    PhosphorIconData(0xf1dd, 'Duotone'),
   );
 
   /// ![thermometer-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/thermometer-simple-duotone.svg)
   static const thermometerSimple = PhosphorDuotoneIconData(
     0xf1e0,
-    PhosphorIconData(0xf1df, 'duotone'),
+    PhosphorIconData(0xf1df, 'Duotone'),
   );
 
   /// ![thumbs-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/thumbs-down-duotone.svg)
   static const thumbsDown = PhosphorDuotoneIconData(
     0xf1e2,
-    PhosphorIconData(0xf1e1, 'duotone'),
+    PhosphorIconData(0xf1e1, 'Duotone'),
   );
 
   /// ![thumbs-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/thumbs-up-duotone.svg)
   static const thumbsUp = PhosphorDuotoneIconData(
     0xf1e4,
-    PhosphorIconData(0xf1e3, 'duotone'),
+    PhosphorIconData(0xf1e3, 'Duotone'),
   );
 
   /// ![ticket-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/ticket-duotone.svg)
   static const ticket = PhosphorDuotoneIconData(
     0xf1e6,
-    PhosphorIconData(0xf1e5, 'duotone'),
+    PhosphorIconData(0xf1e5, 'Duotone'),
   );
 
   /// ![tidal-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/tidal-logo-duotone.svg)
   static const tidalLogo = PhosphorDuotoneIconData(
     0xf1e8,
-    PhosphorIconData(0xf1e7, 'duotone'),
+    PhosphorIconData(0xf1e7, 'Duotone'),
   );
 
   /// ![tiktok-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/tiktok-logo-duotone.svg)
   static const tiktokLogo = PhosphorDuotoneIconData(
     0xf1ea,
-    PhosphorIconData(0xf1e9, 'duotone'),
+    PhosphorIconData(0xf1e9, 'Duotone'),
   );
 
   /// ![timer-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/timer-duotone.svg)
   static const timer = PhosphorDuotoneIconData(
     0xf1ec,
-    PhosphorIconData(0xf1eb, 'duotone'),
+    PhosphorIconData(0xf1eb, 'Duotone'),
   );
 
   /// ![tipi-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/tipi-duotone.svg)
   static const tipi = PhosphorDuotoneIconData(
     0xf1ee,
-    PhosphorIconData(0xf1ed, 'duotone'),
+    PhosphorIconData(0xf1ed, 'Duotone'),
   );
 
   /// ![toggle-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/toggle-left-duotone.svg)
   static const toggleLeft = PhosphorDuotoneIconData(
     0xf1f0,
-    PhosphorIconData(0xf1ef, 'duotone'),
+    PhosphorIconData(0xf1ef, 'Duotone'),
   );
 
   /// ![toggle-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/toggle-right-duotone.svg)
   static const toggleRight = PhosphorDuotoneIconData(
     0xf1f2,
-    PhosphorIconData(0xf1f1, 'duotone'),
+    PhosphorIconData(0xf1f1, 'Duotone'),
   );
 
   /// ![toilet-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/toilet-duotone.svg)
   static const toilet = PhosphorDuotoneIconData(
     0xf1f4,
-    PhosphorIconData(0xf1f3, 'duotone'),
+    PhosphorIconData(0xf1f3, 'Duotone'),
   );
 
   /// ![toilet-paper-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/toilet-paper-duotone.svg)
   static const toiletPaper = PhosphorDuotoneIconData(
     0xf1f6,
-    PhosphorIconData(0xf1f5, 'duotone'),
+    PhosphorIconData(0xf1f5, 'Duotone'),
   );
 
   /// ![toolbox-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/toolbox-duotone.svg)
   static const toolbox = PhosphorDuotoneIconData(
     0xf1f8,
-    PhosphorIconData(0xf1f7, 'duotone'),
+    PhosphorIconData(0xf1f7, 'Duotone'),
   );
 
   /// ![tooth-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/tooth-duotone.svg)
   static const tooth = PhosphorDuotoneIconData(
     0xf1fa,
-    PhosphorIconData(0xf1f9, 'duotone'),
+    PhosphorIconData(0xf1f9, 'Duotone'),
   );
 
   /// ![tote-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/tote-duotone.svg)
   static const tote = PhosphorDuotoneIconData(
     0xf1fc,
-    PhosphorIconData(0xf1fb, 'duotone'),
+    PhosphorIconData(0xf1fb, 'Duotone'),
   );
 
   /// ![tote-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/tote-simple-duotone.svg)
   static const toteSimple = PhosphorDuotoneIconData(
     0xf1fe,
-    PhosphorIconData(0xf1fd, 'duotone'),
+    PhosphorIconData(0xf1fd, 'Duotone'),
   );
 
   /// ![trademark-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/trademark-duotone.svg)
   static const trademark = PhosphorDuotoneIconData(
     0xf200,
-    PhosphorIconData(0xf1ff, 'duotone'),
+    PhosphorIconData(0xf1ff, 'Duotone'),
   );
 
   /// ![trademark-registered-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/trademark-registered-duotone.svg)
   static const trademarkRegistered = PhosphorDuotoneIconData(
     0xf202,
-    PhosphorIconData(0xf201, 'duotone'),
+    PhosphorIconData(0xf201, 'Duotone'),
   );
 
   /// ![traffic-cone-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/traffic-cone-duotone.svg)
   static const trafficCone = PhosphorDuotoneIconData(
     0xf204,
-    PhosphorIconData(0xf203, 'duotone'),
+    PhosphorIconData(0xf203, 'Duotone'),
   );
 
   /// ![traffic-sign-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/traffic-sign-duotone.svg)
   static const trafficSign = PhosphorDuotoneIconData(
     0xf208,
-    PhosphorIconData(0xf207, 'duotone'),
+    PhosphorIconData(0xf207, 'Duotone'),
   );
 
   /// ![traffic-signal-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/traffic-signal-duotone.svg)
   static const trafficSignal = PhosphorDuotoneIconData(
     0xf206,
-    PhosphorIconData(0xf205, 'duotone'),
+    PhosphorIconData(0xf205, 'Duotone'),
   );
 
   /// ![train-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/train-duotone.svg)
   static const train = PhosphorDuotoneIconData(
     0xf20a,
-    PhosphorIconData(0xf209, 'duotone'),
+    PhosphorIconData(0xf209, 'Duotone'),
   );
 
   /// ![train-regional-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/train-regional-duotone.svg)
   static const trainRegional = PhosphorDuotoneIconData(
     0xf20c,
-    PhosphorIconData(0xf20b, 'duotone'),
+    PhosphorIconData(0xf20b, 'Duotone'),
   );
 
   /// ![train-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/train-simple-duotone.svg)
   static const trainSimple = PhosphorDuotoneIconData(
     0xf20e,
-    PhosphorIconData(0xf20d, 'duotone'),
+    PhosphorIconData(0xf20d, 'Duotone'),
   );
 
   /// ![tram-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/tram-duotone.svg)
   static const tram = PhosphorDuotoneIconData(
     0xf210,
-    PhosphorIconData(0xf20f, 'duotone'),
+    PhosphorIconData(0xf20f, 'Duotone'),
   );
 
   /// ![translate-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/translate-duotone.svg)
   static const translate = PhosphorDuotoneIconData(
     0xf212,
-    PhosphorIconData(0xf211, 'duotone'),
+    PhosphorIconData(0xf211, 'Duotone'),
   );
 
   /// ![trash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/trash-duotone.svg)
   static const trash = PhosphorDuotoneIconData(
     0xf214,
-    PhosphorIconData(0xf213, 'duotone'),
+    PhosphorIconData(0xf213, 'Duotone'),
   );
 
   /// ![trash-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/trash-simple-duotone.svg)
   static const trashSimple = PhosphorDuotoneIconData(
     0xf216,
-    PhosphorIconData(0xf215, 'duotone'),
+    PhosphorIconData(0xf215, 'Duotone'),
   );
 
   /// ![tray-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/tray-duotone.svg)
   static const tray = PhosphorDuotoneIconData(
     0xf218,
-    PhosphorIconData(0xf217, 'duotone'),
+    PhosphorIconData(0xf217, 'Duotone'),
   );
 
   /// ![tree-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/tree-duotone.svg)
   static const tree = PhosphorDuotoneIconData(
     0xf21a,
-    PhosphorIconData(0xf219, 'duotone'),
+    PhosphorIconData(0xf219, 'Duotone'),
   );
 
   /// ![tree-evergreen-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/tree-evergreen-duotone.svg)
   static const treeEvergreen = PhosphorDuotoneIconData(
     0xf21c,
-    PhosphorIconData(0xf21b, 'duotone'),
+    PhosphorIconData(0xf21b, 'Duotone'),
   );
 
   /// ![tree-palm-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/tree-palm-duotone.svg)
   static const treePalm = PhosphorDuotoneIconData(
     0xf21e,
-    PhosphorIconData(0xf21d, 'duotone'),
+    PhosphorIconData(0xf21d, 'Duotone'),
   );
 
   /// ![tree-structure-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/tree-structure-duotone.svg)
   static const treeStructure = PhosphorDuotoneIconData(
     0xf220,
-    PhosphorIconData(0xf21f, 'duotone'),
+    PhosphorIconData(0xf21f, 'Duotone'),
   );
 
   /// ![trend-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/trend-down-duotone.svg)
   static const trendDown = PhosphorDuotoneIconData(
     0xf222,
-    PhosphorIconData(0xf221, 'duotone'),
+    PhosphorIconData(0xf221, 'Duotone'),
   );
 
   /// ![trend-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/trend-up-duotone.svg)
   static const trendUp = PhosphorDuotoneIconData(
     0xf224,
-    PhosphorIconData(0xf223, 'duotone'),
+    PhosphorIconData(0xf223, 'Duotone'),
   );
 
   /// ![triangle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/triangle-duotone.svg)
   static const triangle = PhosphorDuotoneIconData(
     0xf226,
-    PhosphorIconData(0xf225, 'duotone'),
+    PhosphorIconData(0xf225, 'Duotone'),
   );
 
   /// ![trophy-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/trophy-duotone.svg)
   static const trophy = PhosphorDuotoneIconData(
     0xf228,
-    PhosphorIconData(0xf227, 'duotone'),
+    PhosphorIconData(0xf227, 'Duotone'),
   );
 
   /// ![truck-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/truck-duotone.svg)
   static const truck = PhosphorDuotoneIconData(
     0xf22a,
-    PhosphorIconData(0xf229, 'duotone'),
+    PhosphorIconData(0xf229, 'Duotone'),
   );
 
   /// ![twitch-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/twitch-logo-duotone.svg)
   static const twitchLogo = PhosphorDuotoneIconData(
     0xf22e,
-    PhosphorIconData(0xf22d, 'duotone'),
+    PhosphorIconData(0xf22d, 'Duotone'),
   );
 
   /// ![twitter-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/twitter-logo-duotone.svg)
   static const twitterLogo = PhosphorDuotoneIconData(
     0xf230,
-    PhosphorIconData(0xf22f, 'duotone'),
+    PhosphorIconData(0xf22f, 'Duotone'),
   );
 
   /// ![umbrella-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/umbrella-duotone.svg)
   static const umbrella = PhosphorDuotoneIconData(
     0xf232,
-    PhosphorIconData(0xf231, 'duotone'),
+    PhosphorIconData(0xf231, 'Duotone'),
   );
 
   /// ![umbrella-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/umbrella-simple-duotone.svg)
   static const umbrellaSimple = PhosphorDuotoneIconData(
     0xf234,
-    PhosphorIconData(0xf233, 'duotone'),
+    PhosphorIconData(0xf233, 'Duotone'),
   );
 
   /// ![unite-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/unite-duotone.svg)
   static const unite = PhosphorDuotoneIconData(
     0xf236,
-    PhosphorIconData(0xf235, 'duotone'),
+    PhosphorIconData(0xf235, 'Duotone'),
   );
 
   /// ![unite-square-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/unite-square-duotone.svg)
   static const uniteSquare = PhosphorDuotoneIconData(
     0xf238,
-    PhosphorIconData(0xf237, 'duotone'),
+    PhosphorIconData(0xf237, 'Duotone'),
   );
 
   /// ![upload-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/upload-duotone.svg)
   static const upload = PhosphorDuotoneIconData(
     0xf23a,
-    PhosphorIconData(0xf239, 'duotone'),
+    PhosphorIconData(0xf239, 'Duotone'),
   );
 
   /// ![upload-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/upload-simple-duotone.svg)
   static const uploadSimple = PhosphorDuotoneIconData(
     0xf23c,
-    PhosphorIconData(0xf23b, 'duotone'),
+    PhosphorIconData(0xf23b, 'Duotone'),
   );
 
   /// ![usb-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/usb-duotone.svg)
   static const usb = PhosphorDuotoneIconData(
     0xf23e,
-    PhosphorIconData(0xf23d, 'duotone'),
+    PhosphorIconData(0xf23d, 'Duotone'),
   );
 
   /// ![user-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/user-duotone.svg)
   static const user = PhosphorDuotoneIconData(
     0xf248,
-    PhosphorIconData(0xf247, 'duotone'),
+    PhosphorIconData(0xf247, 'Duotone'),
   );
 
   /// ![user-circle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/user-circle-duotone.svg)
   static const userCircle = PhosphorDuotoneIconData(
     0xf240,
-    PhosphorIconData(0xf23f, 'duotone'),
+    PhosphorIconData(0xf23f, 'Duotone'),
   );
 
   /// ![user-circle-gear-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/user-circle-gear-duotone.svg)
   static const userCircleGear = PhosphorDuotoneIconData(
     0xf242,
-    PhosphorIconData(0xf241, 'duotone'),
+    PhosphorIconData(0xf241, 'Duotone'),
   );
 
   /// ![user-circle-minus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/user-circle-minus-duotone.svg)
   static const userCircleMinus = PhosphorDuotoneIconData(
     0xf244,
-    PhosphorIconData(0xf243, 'duotone'),
+    PhosphorIconData(0xf243, 'Duotone'),
   );
 
   /// ![user-circle-plus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/user-circle-plus-duotone.svg)
   static const userCirclePlus = PhosphorDuotoneIconData(
     0xf246,
-    PhosphorIconData(0xf245, 'duotone'),
+    PhosphorIconData(0xf245, 'Duotone'),
   );
 
   /// ![user-focus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/user-focus-duotone.svg)
   static const userFocus = PhosphorDuotoneIconData(
     0xf24a,
-    PhosphorIconData(0xf249, 'duotone'),
+    PhosphorIconData(0xf249, 'Duotone'),
   );
 
   /// ![user-gear-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/user-gear-duotone.svg)
   static const userGear = PhosphorDuotoneIconData(
     0xf24c,
-    PhosphorIconData(0xf24b, 'duotone'),
+    PhosphorIconData(0xf24b, 'Duotone'),
   );
 
   /// ![user-list-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/user-list-duotone.svg)
   static const userList = PhosphorDuotoneIconData(
     0xf24e,
-    PhosphorIconData(0xf24d, 'duotone'),
+    PhosphorIconData(0xf24d, 'Duotone'),
   );
 
   /// ![user-minus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/user-minus-duotone.svg)
   static const userMinus = PhosphorDuotoneIconData(
     0xf250,
-    PhosphorIconData(0xf24f, 'duotone'),
+    PhosphorIconData(0xf24f, 'Duotone'),
   );
 
   /// ![user-plus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/user-plus-duotone.svg)
   static const userPlus = PhosphorDuotoneIconData(
     0xf252,
-    PhosphorIconData(0xf251, 'duotone'),
+    PhosphorIconData(0xf251, 'Duotone'),
   );
 
   /// ![user-rectangle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/user-rectangle-duotone.svg)
   static const userRectangle = PhosphorDuotoneIconData(
     0xf254,
-    PhosphorIconData(0xf253, 'duotone'),
+    PhosphorIconData(0xf253, 'Duotone'),
   );
 
   /// ![user-square-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/user-square-duotone.svg)
   static const userSquare = PhosphorDuotoneIconData(
     0xf25a,
-    PhosphorIconData(0xf259, 'duotone'),
+    PhosphorIconData(0xf259, 'Duotone'),
   );
 
   /// ![user-switch-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/user-switch-duotone.svg)
   static const userSwitch = PhosphorDuotoneIconData(
     0xf25e,
-    PhosphorIconData(0xf25d, 'duotone'),
+    PhosphorIconData(0xf25d, 'Duotone'),
   );
 
   /// ![users-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/users-duotone.svg)
   static const users = PhosphorDuotoneIconData(
     0xf256,
-    PhosphorIconData(0xf255, 'duotone'),
+    PhosphorIconData(0xf255, 'Duotone'),
   );
 
   /// ![users-four-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/users-four-duotone.svg)
   static const usersFour = PhosphorDuotoneIconData(
     0xf258,
-    PhosphorIconData(0xf257, 'duotone'),
+    PhosphorIconData(0xf257, 'Duotone'),
   );
 
   /// ![users-three-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/users-three-duotone.svg)
   static const usersThree = PhosphorDuotoneIconData(
     0xf25c,
-    PhosphorIconData(0xf25b, 'duotone'),
+    PhosphorIconData(0xf25b, 'Duotone'),
   );
 
   /// ![van-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/van-duotone.svg)
   static const van = PhosphorDuotoneIconData(
     0xf260,
-    PhosphorIconData(0xf25f, 'duotone'),
+    PhosphorIconData(0xf25f, 'Duotone'),
   );
 
   /// ![vault-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/vault-duotone.svg)
   static const vault = PhosphorDuotoneIconData(
     0xf262,
-    PhosphorIconData(0xf261, 'duotone'),
+    PhosphorIconData(0xf261, 'Duotone'),
   );
 
   /// ![vibrate-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/vibrate-duotone.svg)
   static const vibrate = PhosphorDuotoneIconData(
     0xf264,
-    PhosphorIconData(0xf263, 'duotone'),
+    PhosphorIconData(0xf263, 'Duotone'),
   );
 
   /// ![video-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/video-duotone.svg)
   static const video = PhosphorDuotoneIconData(
     0xf26a,
-    PhosphorIconData(0xf269, 'duotone'),
+    PhosphorIconData(0xf269, 'Duotone'),
   );
 
   /// ![video-camera-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/video-camera-duotone.svg)
   static const videoCamera = PhosphorDuotoneIconData(
     0xf266,
-    PhosphorIconData(0xf265, 'duotone'),
+    PhosphorIconData(0xf265, 'Duotone'),
   );
 
   /// ![video-camera-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/video-camera-slash-duotone.svg)
   static const videoCameraSlash = PhosphorDuotoneIconData(
     0xf268,
-    PhosphorIconData(0xf267, 'duotone'),
+    PhosphorIconData(0xf267, 'Duotone'),
   );
 
   /// ![vignette-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/vignette-duotone.svg)
   static const vignette = PhosphorDuotoneIconData(
     0xf26c,
-    PhosphorIconData(0xf26b, 'duotone'),
+    PhosphorIconData(0xf26b, 'Duotone'),
   );
 
   /// ![vinyl-record-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/vinyl-record-duotone.svg)
   static const vinylRecord = PhosphorDuotoneIconData(
     0xf26e,
-    PhosphorIconData(0xf26d, 'duotone'),
+    PhosphorIconData(0xf26d, 'Duotone'),
   );
 
   /// ![virtual-reality-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/virtual-reality-duotone.svg)
   static const virtualReality = PhosphorDuotoneIconData(
     0xf270,
-    PhosphorIconData(0xf26f, 'duotone'),
+    PhosphorIconData(0xf26f, 'Duotone'),
   );
 
   /// ![virus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/virus-duotone.svg)
   static const virus = PhosphorDuotoneIconData(
     0xf272,
-    PhosphorIconData(0xf271, 'duotone'),
+    PhosphorIconData(0xf271, 'Duotone'),
   );
 
   /// ![voicemail-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/voicemail-duotone.svg)
   static const voicemail = PhosphorDuotoneIconData(
     0xf274,
-    PhosphorIconData(0xf273, 'duotone'),
+    PhosphorIconData(0xf273, 'Duotone'),
   );
 
   /// ![volleyball-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/volleyball-duotone.svg)
   static const volleyball = PhosphorDuotoneIconData(
     0xf276,
-    PhosphorIconData(0xf275, 'duotone'),
+    PhosphorIconData(0xf275, 'Duotone'),
   );
 
   /// ![wall-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/wall-duotone.svg)
   static const wall = PhosphorDuotoneIconData(
     0xf278,
-    PhosphorIconData(0xf277, 'duotone'),
+    PhosphorIconData(0xf277, 'Duotone'),
   );
 
   /// ![wallet-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/wallet-duotone.svg)
   static const wallet = PhosphorDuotoneIconData(
     0xf27a,
-    PhosphorIconData(0xf279, 'duotone'),
+    PhosphorIconData(0xf279, 'Duotone'),
   );
 
   /// ![warehouse-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/warehouse-duotone.svg)
   static const warehouse = PhosphorDuotoneIconData(
     0xf27c,
-    PhosphorIconData(0xf27b, 'duotone'),
+    PhosphorIconData(0xf27b, 'Duotone'),
   );
 
   /// ![warning-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/warning-duotone.svg)
   static const warning = PhosphorDuotoneIconData(
     0xf282,
-    PhosphorIconData(0xf281, 'duotone'),
+    PhosphorIconData(0xf281, 'Duotone'),
   );
 
   /// ![warning-circle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/warning-circle-duotone.svg)
   static const warningCircle = PhosphorDuotoneIconData(
     0xf27e,
-    PhosphorIconData(0xf27d, 'duotone'),
+    PhosphorIconData(0xf27d, 'Duotone'),
   );
 
   /// ![warning-diamond-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/warning-diamond-duotone.svg)
   static const warningDiamond = PhosphorDuotoneIconData(
     0xf280,
-    PhosphorIconData(0xf27f, 'duotone'),
+    PhosphorIconData(0xf27f, 'Duotone'),
   );
 
   /// ![warning-octagon-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/warning-octagon-duotone.svg)
   static const warningOctagon = PhosphorDuotoneIconData(
     0xf284,
-    PhosphorIconData(0xf283, 'duotone'),
+    PhosphorIconData(0xf283, 'Duotone'),
   );
 
   /// ![watch-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/watch-duotone.svg)
   static const watch = PhosphorDuotoneIconData(
     0xf286,
-    PhosphorIconData(0xf285, 'duotone'),
+    PhosphorIconData(0xf285, 'Duotone'),
   );
 
   /// ![wave-sawtooth-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/wave-sawtooth-duotone.svg)
   static const waveSawtooth = PhosphorDuotoneIconData(
     0xf28a,
-    PhosphorIconData(0xf289, 'duotone'),
+    PhosphorIconData(0xf289, 'Duotone'),
   );
 
   /// ![wave-sine-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/wave-sine-duotone.svg)
   static const waveSine = PhosphorDuotoneIconData(
     0xf28e,
-    PhosphorIconData(0xf28d, 'duotone'),
+    PhosphorIconData(0xf28d, 'Duotone'),
   );
 
   /// ![wave-square-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/wave-square-duotone.svg)
   static const waveSquare = PhosphorDuotoneIconData(
     0xf290,
-    PhosphorIconData(0xf28f, 'duotone'),
+    PhosphorIconData(0xf28f, 'Duotone'),
   );
 
   /// ![wave-triangle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/wave-triangle-duotone.svg)
   static const waveTriangle = PhosphorDuotoneIconData(
     0xf292,
-    PhosphorIconData(0xf291, 'duotone'),
+    PhosphorIconData(0xf291, 'Duotone'),
   );
 
   /// ![waveform-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/waveform-duotone.svg)
   static const waveform = PhosphorDuotoneIconData(
     0xf288,
-    PhosphorIconData(0xf287, 'duotone'),
+    PhosphorIconData(0xf287, 'Duotone'),
   );
 
   /// ![waves-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/waves-duotone.svg)
   static const waves = PhosphorDuotoneIconData(
     0xf28c,
-    PhosphorIconData(0xf28b, 'duotone'),
+    PhosphorIconData(0xf28b, 'Duotone'),
   );
 
   /// ![webcam-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/webcam-duotone.svg)
   static const webcam = PhosphorDuotoneIconData(
     0xf294,
-    PhosphorIconData(0xf293, 'duotone'),
+    PhosphorIconData(0xf293, 'Duotone'),
   );
 
   /// ![webcam-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/webcam-slash-duotone.svg)
   static const webcamSlash = PhosphorDuotoneIconData(
     0xf296,
-    PhosphorIconData(0xf295, 'duotone'),
+    PhosphorIconData(0xf295, 'Duotone'),
   );
 
   /// ![webhooks-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/webhooks-logo-duotone.svg)
   static const webhooksLogo = PhosphorDuotoneIconData(
     0xf298,
-    PhosphorIconData(0xf297, 'duotone'),
+    PhosphorIconData(0xf297, 'Duotone'),
   );
 
   /// ![wechat-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/wechat-logo-duotone.svg)
   static const wechatLogo = PhosphorDuotoneIconData(
     0xf29a,
-    PhosphorIconData(0xf299, 'duotone'),
+    PhosphorIconData(0xf299, 'Duotone'),
   );
 
   /// ![whatsapp-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/whatsapp-logo-duotone.svg)
   static const whatsappLogo = PhosphorDuotoneIconData(
     0xf29c,
-    PhosphorIconData(0xf29b, 'duotone'),
+    PhosphorIconData(0xf29b, 'Duotone'),
   );
 
   /// ![wheelchair-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/wheelchair-duotone.svg)
   static const wheelchair = PhosphorDuotoneIconData(
     0xf29e,
-    PhosphorIconData(0xf29d, 'duotone'),
+    PhosphorIconData(0xf29d, 'Duotone'),
   );
 
   /// ![wheelchair-motion-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/wheelchair-motion-duotone.svg)
   static const wheelchairMotion = PhosphorDuotoneIconData(
     0xf2a0,
-    PhosphorIconData(0xf29f, 'duotone'),
+    PhosphorIconData(0xf29f, 'Duotone'),
   );
 
   /// ![wifi-high-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/wifi-high-duotone.svg)
   static const wifiHigh = PhosphorDuotoneIconData(
     0xf2a2,
-    PhosphorIconData(0xf2a1, 'duotone'),
+    PhosphorIconData(0xf2a1, 'Duotone'),
   );
 
   /// ![wifi-low-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/wifi-low-duotone.svg)
   static const wifiLow = PhosphorDuotoneIconData(
     0xf2a4,
-    PhosphorIconData(0xf2a3, 'duotone'),
+    PhosphorIconData(0xf2a3, 'Duotone'),
   );
 
   /// ![wifi-medium-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/wifi-medium-duotone.svg)
   static const wifiMedium = PhosphorDuotoneIconData(
     0xf2a6,
-    PhosphorIconData(0xf2a5, 'duotone'),
+    PhosphorIconData(0xf2a5, 'Duotone'),
   );
 
   /// ![wifi-none-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/wifi-none-duotone.svg)
@@ -7425,66 +7425,66 @@ class PhosphorIconsDuotone {
   /// ![wifi-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/wifi-slash-duotone.svg)
   static const wifiSlash = PhosphorDuotoneIconData(
     0xf2a9,
-    PhosphorIconData(0xf2a8, 'duotone'),
+    PhosphorIconData(0xf2a8, 'Duotone'),
   );
 
   /// ![wifi-x-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/wifi-x-duotone.svg)
   static const wifiX = PhosphorDuotoneIconData(
     0xf2ab,
-    PhosphorIconData(0xf2aa, 'duotone'),
+    PhosphorIconData(0xf2aa, 'Duotone'),
   );
 
   /// ![wind-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/wind-duotone.svg)
   static const wind = PhosphorDuotoneIconData(
     0xf2ad,
-    PhosphorIconData(0xf2ac, 'duotone'),
+    PhosphorIconData(0xf2ac, 'Duotone'),
   );
 
   /// ![windows-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/windows-logo-duotone.svg)
   static const windowsLogo = PhosphorDuotoneIconData(
     0xf2af,
-    PhosphorIconData(0xf2ae, 'duotone'),
+    PhosphorIconData(0xf2ae, 'Duotone'),
   );
 
   /// ![wine-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/wine-duotone.svg)
   static const wine = PhosphorDuotoneIconData(
     0xf2b1,
-    PhosphorIconData(0xf2b0, 'duotone'),
+    PhosphorIconData(0xf2b0, 'Duotone'),
   );
 
   /// ![wrench-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/wrench-duotone.svg)
   static const wrench = PhosphorDuotoneIconData(
     0xf2b3,
-    PhosphorIconData(0xf2b2, 'duotone'),
+    PhosphorIconData(0xf2b2, 'Duotone'),
   );
 
   /// ![x-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/x-duotone.svg)
   static const x = PhosphorDuotoneIconData(
     0xf2b7,
-    PhosphorIconData(0xf2b6, 'duotone'),
+    PhosphorIconData(0xf2b6, 'Duotone'),
   );
 
   /// ![x-circle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/x-circle-duotone.svg)
   static const xCircle = PhosphorDuotoneIconData(
     0xf2b5,
-    PhosphorIconData(0xf2b4, 'duotone'),
+    PhosphorIconData(0xf2b4, 'Duotone'),
   );
 
   /// ![x-square-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/x-square-duotone.svg)
   static const xSquare = PhosphorDuotoneIconData(
     0xf2b9,
-    PhosphorIconData(0xf2b8, 'duotone'),
+    PhosphorIconData(0xf2b8, 'Duotone'),
   );
 
   /// ![yin-yang-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/yin-yang-duotone.svg)
   static const yinYang = PhosphorDuotoneIconData(
     0xf2bb,
-    PhosphorIconData(0xf2ba, 'duotone'),
+    PhosphorIconData(0xf2ba, 'Duotone'),
   );
 
   /// ![youtube-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/youtube-logo-duotone.svg)
   static const youtubeLogo = PhosphorDuotoneIconData(
     0xf2bd,
-    PhosphorIconData(0xf2bc, 'duotone'),
+    PhosphorIconData(0xf2bc, 'Duotone'),
   );
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   clock:
     dependency: transitive
     description:
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.17.1"
   fake_async:
     dependency: transitive
     description:
@@ -63,18 +63,18 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.7"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.13"
+    version: "0.12.15"
   material_color_utilities:
     dependency: transitive
     description:
@@ -87,18 +87,18 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.1"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -148,10 +148,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.16"
+    version: "0.5.1"
   vector_math:
     dependency: transitive
     description:
@@ -161,5 +161,5 @@ packages:
     source: hosted
     version: "2.1.4"
 sdks:
-  dart: ">=2.18.0 <3.0.0"
+  dart: ">=3.0.0-0 <4.0.0"
   flutter: ">=1.17.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.1"
+    version: "1.18.0"
   fake_async:
     dependency: transitive
     description:
@@ -59,38 +59,30 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.7"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.15"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.11.0"
   path:
     dependency: transitive
     description:
@@ -108,26 +100,26 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
@@ -148,10 +140,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.6.1"
   vector_math:
     dependency: transitive
     description:
@@ -160,6 +152,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4-beta"
 sdks:
-  dart: ">=3.0.0 <4.0.0"
-  flutter: ">=3.3.0"
+  dart: ">=3.1.0-185.0.dev <4.0.0"
+  flutter: ">=1.17.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -161,5 +161,5 @@ packages:
     source: hosted
     version: "2.1.4"
 sdks:
-  dart: ">=3.0.0-0 <4.0.0"
-  flutter: ">=1.17.0"
+  dart: ">=3.0.0 <4.0.0"
+  flutter: ">=3.3.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,8 +19,8 @@ screenshots:
     path: meta/screenshot_duotone.png
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.17.0"
+  sdk: ">=3.0.0 <4.0.0"
+  flutter: '>=3.3.0'
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: phosphor_flutter
 description: Implementation of Phosphoricons for Flutter. 772 icons and counting. Thin, Light, Regular, Bold, Fill.
-version: 2.0.0
+version: 2.0.1
 maintainer: Rurick Maqueo Poisot @rurickdev
 homepage: https://phosphoricons.com/
 repository: https://github.com/phosphor-icons/phosphor-flutter
@@ -19,8 +19,8 @@ screenshots:
     path: meta/screenshot_duotone.png
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
-  flutter: '>=3.3.0'
+  sdk: "^2.12.0"
+  flutter: "^1.17.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Current implementation of `PhosphorIcon` widget requires a `PhosphorIconData` which avoids using the widget for any type of Icon. This PR allows using `PhosphorIcon` with generic `IconData`