### PR TITLE
Improve version inside generator

### DIFF
--- a/bin/main.dart
+++ b/bin/main.dart
@@ -53,7 +53,7 @@ Future<void> _processStyleFileInZip(
 ) async {
   print('Working with ${styleData.directoryName} style');
 
-  final styleDirPath = '$version/Fonts/${styleData.styleName}';
+  final styleDirPath = 'Fonts/${styleData.styleName}';
   final fontFileName = styleData.fontFileName;
   final fontExtractFilePath = '../lib/fonts/$fontFileName';
 

--- a/bin/utils.dart
+++ b/bin/utils.dart
@@ -64,19 +64,31 @@ $content''',
   );
 }
 
+class DownloadResult {
+  final Archive archive;
+  final String version;
+
+  DownloadResult({
+    required this.archive,
+    required this.version,
+  });
+}
+
 /// Downloads to memory a the latest release zip [Archive]
 /// from Phosphor Github repository
-Future<Archive> downloadPhosphorZip() async {
+Future<DownloadResult> downloadPhosphorZip() async {
   print('Downloading latest phosphor release zip');
   final client = http.Client();
   final jsonUrl = Uri.parse(
-    'https://api.github.com/repos/phosphor-icons/phosphor-home/releases/latest',
+    'https://api.github.com/repos/phosphor-icons/homepage/releases/latest',
   );
   final request = await client.get(jsonUrl);
   final releaseJson = jsonDecode(request.body);
   final downloadUrl = Uri.tryParse(
     releaseJson['assets'][0]['browser_download_url'] as String? ?? '',
   );
+  var version = releaseJson['tag_name'] as String? ?? '';
+  version = version.replaceFirst('v', '');
 
   if (downloadUrl == null) {
     throw Exception('Download Url is null');
@@ -85,7 +97,10 @@ Future<Archive> downloadPhosphorZip() async {
     print('$downloadUrl');
     print('----------------------------------');
     final fileRequest = await client.get(downloadUrl);
-    return ZipDecoder().decodeBytes(fileRequest.bodyBytes);
+    return DownloadResult(
+      archive: ZipDecoder().decodeBytes(fileRequest.bodyBytes),
+      version: version,
+    );
   }
 }
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -42,10 +42,10 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
@@ -74,14 +74,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  web:
-    dependency: transitive
-    description:
-      name: web
-      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.4-beta"
 sdks:
-  dart: ">=3.1.0-185.0.dev <4.0.0"
+  dart: ">=3.2.0-0 <4.0.0"
   flutter: ">=1.17.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -59,22 +59,46 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.0"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
@@ -87,10 +111,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -152,14 +176,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  web:
+  vm_service:
     dependency: transitive
     description:
-      name: web
-      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      name: vm_service
+      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.4-beta"
+    version: "13.0.0"
 sdks:
-  dart: ">=3.1.0-185.0.dev <4.0.0"
+  dart: ">=3.2.0-0 <4.0.0"
   flutter: ">=1.17.0"


### PR DESCRIPTION
Currently the version needs to be manually changed.
I changed it to be dynamic to the version returned by the github api.

At first, I wanted to upgrade the version to have the new icons but I failed because the phosphor zip isn't there (see https://github.com/phosphor-icons/homepage/issues/457).
Maybe we could also automate this?